### PR TITLE
refactor: EPMCACMAWS-461 Review and optimise logging levels in Lambda Python Code

### DIFF
--- a/terraform/modules/lambdas/functions/ai_handler_comment_lambda/ai_handler_comment_lambda.py
+++ b/terraform/modules/lambdas/functions/ai_handler_comment_lambda/ai_handler_comment_lambda.py
@@ -38,7 +38,7 @@ def process_vcs_webhook_payload(event: Dict[str, Any]) -> Dict[str, Any]:
         ValueError: If the VCS provider specified in the global `config.vcs_provider` is not
             supported or recognized.
     """
-    logger.info('Processing VCS webhook payload...')
+    logger.info('Processing VCS webhook payload.')
     body: str = event.get('body', '{}')
 
     webhook_payload: Dict[str, Any] = json.loads(body)
@@ -121,17 +121,17 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:  # no
         # Handle bot commands from the comment
         handle_comment_commands(event)
 
-        logger.info('Successfully invoked')
+        logger.info('Lambda invocation completed successfully.')
         return {'statusCode': HTTP_SUCCESS, 'body': 'Successfully invoked'}
 
-    except InvalidTokenException as e:
-        logger.warning(f'Invalid token: {str(e)}')
+    except InvalidTokenException as error:
+        logger.error(f'Invalid token: {error}.')
         return {'statusCode': HTTP_FORBIDDEN, 'body': 'Forbidden'}
 
-    except MissingCommentContextException as e:
-        logger.warning(f'No comment context: {str(e)}')
+    except MissingCommentContextException as exception:
+        logger.debug(f'Webhook comment is outside bot command context: {exception}.')
         return {'statusCode': HTTP_SUCCESS, 'body': 'Out of bot context, no action taken'}
 
-    except (json.JSONDecodeError, HTTPException, MissingWebhookDataException, MissingTokenException) as e:
-        logger.error(f'Error in webhook payload: {str(e)}')
+    except (json.JSONDecodeError, HTTPException, MissingWebhookDataException, MissingTokenException) as error:
+        logger.error(f'Failed to process VCS webhook payload: {error}.')
         return {'statusCode': HTTP_BAD_REQUEST, 'body': 'Invalid payload'}

--- a/terraform/modules/lambdas/functions/ai_handler_comment_lambda/ai_handler_comment_lambda.py
+++ b/terraform/modules/lambdas/functions/ai_handler_comment_lambda/ai_handler_comment_lambda.py
@@ -38,7 +38,7 @@ def process_vcs_webhook_payload(event: Dict[str, Any]) -> Dict[str, Any]:
         ValueError: If the VCS provider specified in the global `config.vcs_provider` is not
             supported or recognized.
     """
-    logger.info('Processing VCS webhook payload.')
+    logger.info('Processing VCS webhook payload...')
     body: str = event.get('body', '{}')
 
     webhook_payload: Dict[str, Any] = json.loads(body)

--- a/terraform/modules/lambdas/functions/ai_handler_tf_errors_lambda/ai_handler_tf_errors_lambda.py
+++ b/terraform/modules/lambdas/functions/ai_handler_tf_errors_lambda/ai_handler_tf_errors_lambda.py
@@ -49,9 +49,6 @@ def process_s3_event(event: Dict[str, Any]) -> Dict[str, Any]:
 
         log_file_content_with_metadata: Dict[str, Any] | None = get_file_content_with_metadata_from_s3(s3_bucket,
                                                                                                        s3_key)
-
-        logger.info(f"log_file_content_with_metadata --->\n{log_file_content_with_metadata}")
-
         log_file_content: str = log_file_content_with_metadata.get('content')
 
         file_metadata: Dict[str, str] = log_file_content_with_metadata.get('metadata')
@@ -77,7 +74,7 @@ def process_s3_event(event: Dict[str, Any]) -> Dict[str, Any]:
         return event
 
     except Exception as error:
-        logger.error(f"Error occurred while processing the S3 event: {str(error)}")
+        logger.error(f"Error occurred while processing the S3 event: {error}.")
         raise error
 
 
@@ -112,7 +109,6 @@ def lambda_handler(event: dict[str, dict], context: Any) -> Dict[str, Any]:  # n
         user_prompt: List = [user_message]
         generated_response: Dict[str, Any] = generate_response_ai(user_prompt)
         message: str = generated_response.get("message", "").strip()
-        logger.info(f"Message to UI --->\n{message}")
         event.get("metadata").update({"ai_response": message})
 
         tool_name = event.get("metadata").get("tool_name")
@@ -127,9 +123,9 @@ def lambda_handler(event: dict[str, dict], context: Any) -> Dict[str, Any]:  # n
         handle_ai_response_message(event)
         create_context_memory_window(event)
 
-        logger.info('Successfully invoked')
+        logger.info('Successfully invoked.')
 
 
     except Exception as error:
-        logger.error(f"Error occurred while invoking the Lambda function: {str(error)}")
+        logger.error(f"Error occurred while invoking the Lambda function: {error}.")
         raise error

--- a/terraform/modules/lambdas/functions/tests/lambda_handlers/test_ai_handler_comment_lambda.py
+++ b/terraform/modules/lambdas/functions/tests/lambda_handlers/test_ai_handler_comment_lambda.py
@@ -7,7 +7,7 @@ def test_process_vcs_webhook_payload_github(patched_config_github, webhook_event
                         lambda x, y: "1234")
     from ai_handler_comment_lambda.ai_handler_comment_lambda import process_vcs_webhook_payload
     result = process_vcs_webhook_payload(webhook_event_github)
-    assert 'Processing VCS webhook payload.' in caplog.text
+    assert 'Processing VCS webhook payload...' in caplog.text
     assert isinstance(result, dict)
     assert webhook_event_github.get('metadata')
     assert result.get('metadata') == expected_webhook_event_metadata_github
@@ -17,7 +17,7 @@ def test_process_vcs_webhook_payload_gitlab(patched_config_gitlab, webhook_event
                                             expected_webhook_event_metadata_gitlab, caplog):
     from ai_handler_comment_lambda.ai_handler_comment_lambda import process_vcs_webhook_payload
     result = process_vcs_webhook_payload(webhook_event_gitlab)
-    assert 'Processing VCS webhook payload.' in caplog.text
+    assert 'Processing VCS webhook payload...' in caplog.text
     assert isinstance(result, dict)
     assert result.get('metadata')
     assert webhook_event_gitlab.get('metadata')

--- a/terraform/modules/lambdas/functions/tests/lambda_handlers/test_ai_handler_comment_lambda.py
+++ b/terraform/modules/lambdas/functions/tests/lambda_handlers/test_ai_handler_comment_lambda.py
@@ -7,7 +7,7 @@ def test_process_vcs_webhook_payload_github(patched_config_github, webhook_event
                         lambda x, y: "1234")
     from ai_handler_comment_lambda.ai_handler_comment_lambda import process_vcs_webhook_payload
     result = process_vcs_webhook_payload(webhook_event_github)
-    assert 'Processing VCS webhook payload...' in caplog.text
+    assert 'Processing VCS webhook payload.' in caplog.text
     assert isinstance(result, dict)
     assert webhook_event_github.get('metadata')
     assert result.get('metadata') == expected_webhook_event_metadata_github
@@ -17,7 +17,7 @@ def test_process_vcs_webhook_payload_gitlab(patched_config_gitlab, webhook_event
                                             expected_webhook_event_metadata_gitlab, caplog):
     from ai_handler_comment_lambda.ai_handler_comment_lambda import process_vcs_webhook_payload
     result = process_vcs_webhook_payload(webhook_event_gitlab)
-    assert 'Processing VCS webhook payload...' in caplog.text
+    assert 'Processing VCS webhook payload.' in caplog.text
     assert isinstance(result, dict)
     assert result.get('metadata')
     assert webhook_event_gitlab.get('metadata')

--- a/terraform/modules/lambdas/functions/tests/utilities/auth/test_auth.py
+++ b/terraform/modules/lambdas/functions/tests/utilities/auth/test_auth.py
@@ -5,7 +5,7 @@ def test_verify_token_gitlab(patched_config_gitlab, x_gitlab_token, expected_tok
     from utilities.auth import verify_token
     verify_token(x_gitlab_token, expected_token_gitlab)
 
-    assert 'Token successfully verified!' in caplog.text
+    assert 'Webhook token verified successfully.' in caplog.text
 
 
 def test_verify_token_invalid_token_gitlab(patched_config_gitlab, x_gitlab_token, invalid_token_gitlab):
@@ -27,13 +27,13 @@ def test_verify_token_missing_token_gitlab(patched_config_gitlab, expected_token
 def test_webhook_authenticator_success_gitlab(patched_config_gitlab, webhook_event_gitlab, caplog):
     from utilities.auth import webhook_authenticator
     webhook_authenticator(webhook_event_gitlab)
-    assert 'Token successfully verified!' in caplog.text
+    assert 'Webhook token verified successfully.' in caplog.text
 
 
 def test_webhook_authenticator_success_github(patched_config_github, webhook_event_github, caplog):
     from utilities.auth import webhook_authenticator
     webhook_authenticator(webhook_event_github)
-    assert 'Signature successfully verified!' in caplog.text
+    assert 'Webhook signature verified successfully.' in caplog.text
 
 
 def test_webhook_authenticator_wrong_vcs_provider(patched_config_github, webhook_event_github, caplog):
@@ -49,7 +49,7 @@ def test_webhook_authenticator_wrong_vcs_provider(patched_config_github, webhook
 def test_verify_signature_success_github(webhook_event_github, expected_token_github, caplog):
     from utilities.auth import verify_signature
     verify_signature(webhook_event_github, expected_token_github)
-    assert 'Signature successfully verified!' in caplog.text
+    assert 'Webhook signature verified successfully.' in caplog.text
 
 
 def test_verify_signature_invalid_token_github(webhook_event_github, invalid_token_github):

--- a/terraform/modules/lambdas/functions/tests/utilities/handlers/test_handlers.py
+++ b/terraform/modules/lambdas/functions/tests/utilities/handlers/test_handlers.py
@@ -112,7 +112,7 @@ def test_handle_comment_commands_webhook_bot_approve_all_context(patched_environ
     assert 'Bot context found in the comment.' in caplog.text
     assert 'Approve context found in the comment.' in caplog.text
     assert 'Processing approve command...' in caplog.text
-    assert 'Approving all rest_comment...' in caplog.text
+    assert 'Approving all corrected files...' in caplog.text
 
 
 def test_build_approval_commit_message_uses_files_only(patched_environment):
@@ -247,7 +247,7 @@ def test_handle_approve_command_all_stops_when_repo_check_fails(patched_environm
     handlers.handle_approve_command(webhook_event_command_bot_approve_all_context_github, ['all'])
 
     assert commit_calls == []
-    assert comments == ['Some files do not exist in the repository']
+    assert comments == ['Some approved files do not exist in the repository']
 
 
 def test_handle_approve_command_specific_checks_repo_before_commit(patched_environment,
@@ -277,7 +277,7 @@ def test_handle_approve_command_specific_checks_repo_before_commit(patched_envir
     handlers.handle_approve_command(webhook_event_command_bot_approve_all_context_github, ['demo/broken/main.tf'])
 
     assert commit_calls == []
-    assert comments == ['Some requested files do not exist in the repository']
+    assert comments == ['Some selected files do not exist in the repository.']
 
 
 def test_handle_approve_command_specific_deletes_artifacts_after_commit(patched_environment,

--- a/terraform/modules/lambdas/functions/tests/utilities/handlers/test_handlers.py
+++ b/terraform/modules/lambdas/functions/tests/utilities/handlers/test_handlers.py
@@ -53,7 +53,7 @@ def test_handle_comment_commands_webhook_bot_list_context(patched_environment, w
     handlers.handle_comment_commands(webhook_event_command_bot_list_github)
     assert 'Bot context found in the comment.' in caplog.text
     assert 'Processing list command...' in caplog.text
-    assert 'Listing rest_comment: `..`' in caplog.text
+    assert 'Prepared artifact file list: `..`.' in caplog.text
 
 
 def test_handle_comment_commands_webhook_bot_list_context_no_files(patched_environment, webhook_event_command_bot_list_github, caplog,
@@ -72,7 +72,7 @@ def test_handle_comment_commands_webhook_bot_list_context_no_files(patched_envir
     handlers.handle_comment_commands(webhook_event_command_bot_list_github)
     assert 'Bot context found in the comment.' in caplog.text
     assert 'Processing list command...' in caplog.text
-    assert 'Listing rest_comment: `demo/broken/main.tf`\n\n`demo/broken/validate.tf`' in caplog.text
+    assert 'Prepared artifact file list: `demo/broken/main.tf`\n\n`demo/broken/validate.tf`.' in caplog.text
 
 
 def test_handle_comment_commands_webhook_bot_approve_context_mising(patched_environment, 

--- a/terraform/modules/lambdas/functions/utilities/ai/chat_completions.py
+++ b/terraform/modules/lambdas/functions/utilities/ai/chat_completions.py
@@ -50,6 +50,7 @@ def generate_response_ai(messages: list, retries: int = 3) -> dict:
     attempt = 0
 
     while True:
+        logger.debug(f"Requesting AI API with baseurl: {config.ai_api_endpoint}")
         try:
             resp = requests.post(
                 config.ai_api_endpoint,

--- a/terraform/modules/lambdas/functions/utilities/ai/context.py
+++ b/terraform/modules/lambdas/functions/utilities/ai/context.py
@@ -114,8 +114,10 @@ def create_context_memory_window(
 
             put_messages_to_db(config.table_name, messages_to_db)
 
-            logger.info(
-                f"Context window stored pk={commit_short_sha}, sk={messages_to_db[0]['sk']}, {messages_to_db[1]['sk']}")
+            logger.debug(
+                f"Stored context window for pk={commit_short_sha} "
+                f"with sk={messages_to_db[0]['sk']} and {messages_to_db[1]['sk']}."
+            )
             return
 
         except ClientError as e:
@@ -127,13 +129,16 @@ def create_context_memory_window(
                     "ProvisionedThroughputExceededException",
             ):
                 if attempt >= max_retries:
-                    logger.error(f"Failed to store context after {max_retries} retries pk={commit_short_sha}")
+                    logger.error(
+                        f"Failed to store context after {max_retries} retries "
+                        f"for pk={commit_short_sha}."
+                    )
                     raise
                 # Backoff time
                 backoff_time: int = 2 ** attempt
                 logger.warning(
-                    f"Retrying store context attempt {attempt}/{max_retries}, "
-                    f"pk={commit_short_sha} after {backoff_time}s delay"
+                    f"Retrying context storage. Attempt {attempt}/{max_retries} "
+                    f"for pk={commit_short_sha}; waiting {backoff_time}s."
                 )
                 time.sleep(backoff_time)
                 continue  # Ensure the loop retries on ClientError
@@ -186,16 +191,17 @@ def get_context_memory_window(
 
         except ClientError:
             if attempt >= max_retries:
-                logger.exception(f"Failed to fetch context after {max_retries} retries pk={commit_short_sha}")
+                logger.exception(
+                    f"Failed to fetch context after {max_retries} retries "
+                    f"for pk={commit_short_sha}."
+                )
                 raise
-            logger.warning(
-                f"Retrying context fetch due to ClientError attempt {attempt}/{max_retries}, pk={commit_short_sha})"
-            )
             # Backoff time
             backoff_time: int = 2 ** attempt
             logger.warning(
-                f"Retrying fetch context attempt {attempt}/{max_retries}, "
-                f"pk={commit_short_sha} after {backoff_time}s delay"
+                f"Retrying context fetch after ClientError. "
+                f"Attempt {attempt}/{max_retries} for pk={commit_short_sha}; "
+                f"waiting {backoff_time}s."
             )
             time.sleep(backoff_time)
             continue  # Ensure the loop retries on ClientError

--- a/terraform/modules/lambdas/functions/utilities/ai/prompt.py
+++ b/terraform/modules/lambdas/functions/utilities/ai/prompt.py
@@ -93,8 +93,8 @@ def make_prompt_block_with_errors_and_files(event: Dict[str, Any],
     extracted_blocks: list[tuple[str, str]] = extract_blocks_working_directory(errors_data)
 
     for working_directory, errors in extracted_blocks:
-        logger.info(f"Working directory ---> \n{working_directory}")
-        logger.info(f"Extracted block ---> \n{errors}")
+        logger.debug(f"Parsed working directory: {working_directory}.")
+        logger.debug(f"Extracted error block >\n{errors}")
         files_block = """"""
         errors, paths_to_files = process_utilities_error_blocks(working_directory, errors, tool_name_lower)
 
@@ -105,7 +105,7 @@ def make_prompt_block_with_errors_and_files(event: Dict[str, Any],
 
         prompt_block += errors + "\n\n" + guide_block + "\n\n" + files_block + "\n"
 
-    logger.info(f"Prompt block ---> \n{prompt_block}")
+    logger.debug(f"Prepared prompt >\n{prompt_block}")
 
     return prompt_block
 

--- a/terraform/modules/lambdas/functions/utilities/auth.py
+++ b/terraform/modules/lambdas/functions/utilities/auth.py
@@ -29,7 +29,7 @@ def verify_token(token_from_header: str, expected_token: str) -> None:
         # Token missing, raise an exception
         raise MissingTokenException('X-Gitlab-Token header is missing!')
 
-    logger.info('Token successfully verified!')
+    logger.info('Webhook token verified successfully.')
 
 
 def webhook_authenticator(event: Dict[str, Any]):
@@ -51,12 +51,12 @@ def webhook_authenticator(event: Dict[str, Any]):
         case "gitlab" if 'x-gitlab-token' in event.get('headers', {}):
             # Verify the GitLab token
             token_from_header: str = event.get('headers', {}).get('x-gitlab-token')
-            logger.info(f"Webhook authentication for {config.vcs_provider}")
+            logger.info(f"Authenticating {config.vcs_provider} webhook.")
             verify_token(token_from_header, config.webhook_secret)
         case 'github' if 'x-hub-signature-256' in event.get('headers', {}):
 
             # Verify the GitHub signature
-            logger.info(f"Webhook authentication for {config.vcs_provider}")
+            logger.info(f"Authenticating {config.vcs_provider} webhook.")
             verify_signature(event, config.webhook_secret)
 
         case _:
@@ -92,7 +92,7 @@ def verify_signature(event, secret_token) -> None:
     if not hmac.compare_digest(expected_signature, signature_header):
         raise HTTPException(status_code=403, detail="Request signatures didn't match!")
 
-    logger.info('Signature successfully verified!')
+    logger.info('Webhook signature verified successfully.')
 
 
 def is_github_issue_comment(event: Dict[str, Any]) -> bool:

--- a/terraform/modules/lambdas/functions/utilities/aws.py
+++ b/terraform/modules/lambdas/functions/utilities/aws.py
@@ -250,7 +250,7 @@ def get_particular_files_from_s3_directory(
     return files
 
 
-def get_file_content_with_metadata_from_s3(s3_bucket: str, s3_key: str) -> Dict | None:
+def get_file_content_with_metadata_from_s3(s3_bucket: str, s3_key: str) -> Dict:
     """
     Retrieves the content and metadata of a specified file stored in an S3 bucket.
 

--- a/terraform/modules/lambdas/functions/utilities/handlers.py
+++ b/terraform/modules/lambdas/functions/utilities/handlers.py
@@ -35,17 +35,20 @@ def handle_ai_response_message(event: Dict[str, Any]) -> None:
     """
     response_message = event.get('metadata', {}).get('ai_response')
     if not response_message:
-        logger.debug("No response message from AI found in the event metadata.")
+        logger.debug("No AI response message found in event metadata.")
         return
     filenames_with_hcl_blocks: dict[str, str] = parse_hcl_blocks(response_message)
     if filenames_with_hcl_blocks:
-        logger.info(f"Found HCL blocks in the response: {filenames_with_hcl_blocks}")
+        logger.debug(f"Extracted HCL blocks from AI response: {filenames_with_hcl_blocks}.")
         pull_number = event.get('metadata', {}).get('merge_or_pull_req_id')
         if not pull_number:
             raise InvalidEventMetadata("Pull/Merge request ID not found in the event metadata.")
         path_to_artifacts = f"{config.path_to_artifacts}/{pull_number}/"
         delete_files_from_s3(config.artifacts_bucket, path_to_artifacts)
-        logger.info(f"Uploading files to S3 bucket '{config.artifacts_bucket}' for PR #{pull_number}")
+        logger.debug(
+            f"Uploading generated files to S3 bucket '{config.artifacts_bucket}' "
+            f"for pull/merge request #{pull_number}."
+        )
         upload_files_to_s3(config.artifacts_bucket, pull_number, filenames_with_hcl_blocks)
 
 
@@ -66,7 +69,7 @@ def handle_comment_commands(event: Dict[str, Any]) -> None:
         event: Event payload containing ``comment_text`` in metadata.
     """
     comment_context, *rest_comment = event.get('metadata', {}).get('comment_text', '_').split()
-    logger.info(f'Comment context --->\n{comment_context}')
+    logger.debug(f"Parsed comment context: {comment_context}")
     if comment_context == 'bot':
         logger.info('Bot context found in the comment.')
         handle_bot_commands(event, rest_comment)
@@ -96,7 +99,7 @@ def handle_list_command(event: Dict[str, Any]) -> None:
     else:
         files_list = '`..`'
 
-    logger.info(f'Listing rest_comment: {files_list}')
+    logger.debug(f"Prepared artifact file list: {files_list}.")
     post_comment(event, LIST_FILES_MESSAGE.format(files_list=files_list))
 
 
@@ -108,14 +111,13 @@ def handle_bot_commands(event: Dict[str, Any], rest_comment: List[str]) -> None:
         rest_comment: Comment tokens after the leading ``bot`` keyword.
     """
     logger.info('Processing bot commands...')
-
+    logger.debug(f"Parsed command arguments: {rest_comment}.")
     if rest_comment:
         command: str = rest_comment[0]
         rest_comment: List[str] = rest_comment[1:]
 
         if command == 'approve' and rest_comment:
             logger.info('Approve context found in the comment.')
-            logger.info(f'Rest comment ---> {rest_comment}')
             handle_approve_command(event, rest_comment)
 
         elif command == 'list':
@@ -147,10 +149,10 @@ def handle_prompt_command(event: Dict[str, Any], rest_comment: List[str]) -> Non
     user_message = {'content': prompt, 'role': 'user'}
     messages_for_ai = get_context_memory_window(event) + [user_message]
 
-    logger.info(f"Messages to AI ---> {messages_for_ai}")
+    logger.debug(f"Messages prepared for sending to AI: {messages_for_ai}.")
     response = generate_response_ai(messages_for_ai)
 
-    logger.info(f"Response from AI ---> {response}")
+    logger.info(f"Received AI response >\n{response}")
 
     event.setdefault("metadata", {}).update({"prompt": prompt, "ai_response": response["message"].strip()})
 
@@ -220,7 +222,7 @@ def handle_approve_command(event: Dict[str, Any], rest_comment: List[str]) -> No
     """
     logger.info('Processing approve command...')
     if rest_comment[0] in {'*', 'all'}:
-        logger.info('Approving all rest_comment...')
+        logger.info('Approving all corrected files...')
         add_award_to_note(event, SUCCESS)
 
         merge_or_pull_req_id = event.get('metadata', {}).get('merge_or_pull_req_id')
@@ -229,18 +231,18 @@ def handle_approve_command(event: Dict[str, Any], rest_comment: List[str]) -> No
             config.artifacts_bucket, path_to_files_for_approval
         )
 
-        logger.debug(f"Files with its content ---> {file_names_with_content}")
+        logger.debug(f"Corrected files from S3 artifacts with its content: {file_names_with_content}")
 
         if file_names_with_content:
-            logger.info('Committing all corrected files...')
+            logger.info('Committing all approved corrected files...')
 
             # Check if files exist in VCS repository
             files_to_check: list[str] = [file_key for file_key, _ in file_names_with_content]
 
             if not check_files_exist_in_repo(event, files_to_check):
-                logger.warning('Some files do not exist in the repository')
+                logger.warning('Some approved files do not exist in the repository.')
                 add_award_to_note(event, FAILURE)
-                post_comment(event, 'Some files do not exist in the repository')
+                post_comment(event, 'Some approved files do not exist in the repository')
                 return
 
             commit_message = build_approval_commit_message(files_to_check)
@@ -255,22 +257,22 @@ def handle_approve_command(event: Dict[str, Any], rest_comment: List[str]) -> No
         wrong_files = [file_name for file_name in rest_comment if file_name not in fixed_files]
         #
         if wrong_files:
-            logger.warning(f'Invalid rest_comment specified: {wrong_files}')
+            logger.warning(f'Requested files are not available for approval: {wrong_files}.')
             # add_award_to_note(event, 'rotating_light')
             post_comment(event, f'Invalid rest_comment: {wrong_files}')
         else:
             add_award_to_note(event, SUCCESS)
-            logger.info(f"Fixed files ---> {fixed_files}")
+
             if not check_files_exist_in_repo(event, rest_comment):
-                logger.warning('Some requested files do not exist in the repository')
+                logger.warning('Some selected files do not exist in the repository.')
                 add_award_to_note(event, FAILURE)
-                post_comment(event, 'Some requested files do not exist in the repository')
+                post_comment(event, 'Some selected files do not exist in the repository.')
                 return
 
             files_names_with_content: list[tuple[str, str]] = get_particular_files_from_s3_directory(
                 config.artifacts_bucket, path_to_files_for_approval, rest_comment
             )
-            logger.info(f"Files with its content ---> {files_names_with_content}")
+
             commit_message = build_approval_commit_message(rest_comment)
             commit_files_to_branch(event, files_names_with_content, commit_message)
             delete_files_from_s3(config.artifacts_bucket, path_to_files_for_approval)

--- a/terraform/modules/lambdas/functions/utilities/logger.py
+++ b/terraform/modules/lambdas/functions/utilities/logger.py
@@ -3,5 +3,5 @@ import os
 from logging import Logger
 
 log_level = os.environ.get("LOG_LEVEL", "INFO")
-logger: Logger = logging.getLogger()
+logger: Logger = logging.getLogger(name="braintf")
 logger.setLevel(log_level)

--- a/terraform/modules/lambdas/functions/utilities/vcs/github_functions.py
+++ b/terraform/modules/lambdas/functions/utilities/vcs/github_functions.py
@@ -194,9 +194,9 @@ def check_files_exist_in_repo_github(event: Dict[str, Any],
         branch = get_pr_source_branch_name(repo_id_or_name, merge_or_pull_req_id)
         gh = _get_github_client()
         repo = gh.get_repo(repo_id_or_name)
-        logger.info(
-            f"Checking existence of {len(file_paths)} file(s) in repo '{repo_id_or_name}' "
-            f"on branch '{branch}'."
+        logger.debug(
+            f"Checking existence of {len(file_paths)} file(s) in repo {repo_id_or_name} "
+            f"on branch {branch}."
         )
 
         missing_files: list[str] = []
@@ -207,14 +207,14 @@ def check_files_exist_in_repo_github(event: Dict[str, Any],
                 repo.get_contents(path, ref=branch)
                 logger.debug(f"File exists in repo: {path}")
             except UnknownObjectException:
-                logger.warning(f"File does not exist in repo on branch '{branch}': {path}")
+                logger.warning(f"File does not exist in repo on branch {branch}: {path}")
                 missing_files.append(path)
 
         if missing_files:
-            logger.info(f"Missing {len(missing_files)} file(s) in repo: {missing_files}")
+            logger.warning(f"Missing {len(missing_files)} file(s) in repo: {missing_files}")
             return False
 
-        logger.info("All files exist in the repository on the specified branch.")
+        logger.info("All files exist in the GitHub repository on the specified branch.")
         return True
 
     except BadCredentialsException as e:
@@ -258,14 +258,14 @@ def commit_files_to_branch_github(event: Dict[str, Any], file_paths_with_content
         # Get reference and latest commit
         ref = repo.get_git_ref(f"heads/{branch}")
         latest_commit = repo.get_git_commit(ref.object.sha)
-        logger.info(f"Latest commit on branch '{branch}': {latest_commit.sha}")
+        logger.debug(f"Latest commit on branch {branch}: {latest_commit.sha}")
 
         # Prepare tree elements
         tree_elements = []
 
         for path, content in file_paths_with_content:
             blob = repo.create_git_blob(content, "utf-8")
-            logger.info(f"Created Git blob for '{path}' with SHA '{blob.sha}'")
+            logger.debug(f"Created Git blob for {path} with SHA {blob.sha}")
             element = InputGitTreeElement(
                 path=path,
                 mode="100644",
@@ -273,7 +273,7 @@ def commit_files_to_branch_github(event: Dict[str, Any], file_paths_with_content
                 sha=blob.sha,
             )
             tree_elements.append(element)
-        logger.info(f"Prepared Git tree element(s): {tree_elements} for commit")
+        logger.debug(f"Prepared Git tree element(s): {tree_elements} for commit")
 
         # Create a new tree
         new_tree = repo.create_git_tree(tree_elements, base_tree=latest_commit.tree)
@@ -284,7 +284,7 @@ def commit_files_to_branch_github(event: Dict[str, Any], file_paths_with_content
         # Point a branch to the new commit
         ref.edit(new_commit.sha)
 
-        logger.info(f"Successfully committed file(s) {file_paths_with_content} to branch '{branch}'.")
+        logger.debug(f"Successfully committed file(s) {file_paths_with_content} to branch {branch}.")
 
 
     except BadCredentialsException as e:
@@ -344,6 +344,6 @@ def get_all_tf_files_from_paths_list_github(
 
         for item in items:
             if item.type == "file" and item.path.endswith(".tf"):
-                logger.info(f"Fetching Terraform file '{item.path}' from GitHub...")
+                logger.info(f"Terraform file {item.path} fetched from GitHub...")
                 tf_files.append((item.path, item.decoded_content.decode("utf-8")))
     return tf_files

--- a/terraform/modules/lambdas/functions/utilities/vcs/github_functions.py
+++ b/terraform/modules/lambdas/functions/utilities/vcs/github_functions.py
@@ -195,8 +195,8 @@ def check_files_exist_in_repo_github(event: Dict[str, Any],
         gh = _get_github_client()
         repo = gh.get_repo(repo_id_or_name)
         logger.debug(
-            f"Checking existence of {len(file_paths)} file(s) in repo {repo_id_or_name} "
-            f"on branch {branch}."
+            f"Checking existence of {len(file_paths)} file(s) in repo '{repo_id_or_name}' "
+            f"on branch '{branch}'."
         )
 
         missing_files: list[str] = []
@@ -207,7 +207,7 @@ def check_files_exist_in_repo_github(event: Dict[str, Any],
                 repo.get_contents(path, ref=branch)
                 logger.debug(f"File exists in repo: {path}")
             except UnknownObjectException:
-                logger.warning(f"File does not exist in repo on branch {branch}: {path}")
+                logger.warning(f"File does not exist in repo on branch '{branch}': {path}")
                 missing_files.append(path)
 
         if missing_files:
@@ -258,7 +258,7 @@ def commit_files_to_branch_github(event: Dict[str, Any], file_paths_with_content
         # Get reference and latest commit
         ref = repo.get_git_ref(f"heads/{branch}")
         latest_commit = repo.get_git_commit(ref.object.sha)
-        logger.debug(f"Latest commit on branch {branch}: {latest_commit.sha}")
+        logger.debug(f"Latest commit on branch '{branch}': {latest_commit.sha}")
 
         # Prepare tree elements
         tree_elements = []
@@ -284,7 +284,7 @@ def commit_files_to_branch_github(event: Dict[str, Any], file_paths_with_content
         # Point a branch to the new commit
         ref.edit(new_commit.sha)
 
-        logger.debug(f"Successfully committed file(s) {file_paths_with_content} to branch {branch}.")
+        logger.debug(f"Successfully committed file(s) {file_paths_with_content} to branch '{branch}'.")
 
 
     except BadCredentialsException as e:

--- a/terraform/modules/lambdas/functions/utilities/vcs/github_functions.py
+++ b/terraform/modules/lambdas/functions/utilities/vcs/github_functions.py
@@ -39,7 +39,7 @@ def _get_github_client() -> Github:
         client.get_user()  # verifies the token and session
     except Exception as e:
         # Do NOT cache a failed session, let the exception propagate
-        logger.error(f"GitHub client verification failed: {e}")
+        logger.error(f"GitHub client verification failed: {e}.")
         raise
 
     return client  # gets cached only if everything above succeeds
@@ -68,16 +68,16 @@ def get_pr_source_branch_name(repo_id_or_name: Union[int, str], pull_number: int
         return pr.head.ref
 
     except BadCredentialsException as e:
-        logger.error(f"GitHub authentication error: {e}")
+        logger.error(f"GitHub authentication error: {e}.")
         raise
     except UnknownObjectException as e:
-        logger.error(f"GitHub object not found: {e}")
+        logger.error(f"GitHub object not found: {e}.")
         raise
     except GithubException as e:
-        logger.error(f"GitHub API error: {e}")
+        logger.error(f"GitHub API error: {e}.")
         raise
     except Exception as e:
-        logger.error(f"Unexpected error getting PR source branch: {e}")
+        logger.error(f"Unexpected error getting PR source branch: {e}.")
         raise
 
 
@@ -111,16 +111,16 @@ def add_reaction_to_pr_comment_github(event: Dict[str, Any], reaction: str, ):
         return issue_comment
 
     except BadCredentialsException as e:
-        logger.error(f"GitHub authentication error: {e}")
+        logger.error(f"GitHub authentication error: {e}.")
         raise
     except UnknownObjectException as e:
-        logger.error(f"GitHub object not found: {e}")
+        logger.error(f"GitHub object not found: {e}.")
         raise
     except GithubException as e:
-        logger.error(f"GitHub API error: {e}")
+        logger.error(f"GitHub API error: {e}.")
         raise
     except Exception as e:
-        logger.error(f"Unexpected error adding reaction to GitHub PR comment: {e}")
+        logger.error(f"Unexpected error adding reaction to GitHub PR comment: {e}.")
         raise
 
 
@@ -152,16 +152,16 @@ def post_pr_comment_github(event: Dict[str, Any], comment_text: str):
         return issue_comment
 
     except BadCredentialsException as e:
-        logger.error(f"GitHub authentication error: {e}")
+        logger.error(f"GitHub authentication error: {e}.")
         raise
     except UnknownObjectException as e:
-        logger.error(f"GitHub object not found: {e}")
+        logger.error(f"GitHub object not found: {e}.")
         raise
     except GithubException as e:
-        logger.error(f"GitHub API error: {e}")
+        logger.error(f"GitHub API error: {e}.")
         raise
     except Exception as e:
-        logger.error(f"Unexpected error posting comment to GitHub PR: {e}")
+        logger.error(f"Unexpected error posting comment to GitHub PR: {e}.")
         raise
 
 
@@ -195,7 +195,8 @@ def check_files_exist_in_repo_github(event: Dict[str, Any],
         gh = _get_github_client()
         repo = gh.get_repo(repo_id_or_name)
         logger.info(
-            f"Checking existence of {len(file_paths)} file(s) in repo '{repo_id_or_name}' on branch '{branch}'"
+            f"Checking existence of {len(file_paths)} file(s) in repo '{repo_id_or_name}' "
+            f"on branch '{branch}'."
         )
 
         missing_files: list[str] = []
@@ -217,17 +218,17 @@ def check_files_exist_in_repo_github(event: Dict[str, Any],
         return True
 
     except BadCredentialsException as e:
-        logger.error(f"GitHub authentication error while checking file existence: {e}")
+        logger.error(f"GitHub authentication error while checking file existence: {e}.")
         raise
     except UnknownObjectException as e:
         # This usually indicates repo or branch doesn't exist
-        logger.error(f"GitHub object not found while checking file existence: {e}")
+        logger.error(f"GitHub object not found while checking file existence: {e}.")
         raise
     except GithubException as e:
-        logger.error(f"GitHub API error while checking file existence: {e}")
+        logger.error(f"GitHub API error while checking file existence: {e}.")
         raise
     except Exception as e:
-        logger.error(f"Unexpected error while checking file existence in GitHub repo: {e}")
+        logger.error(f"Unexpected error while checking file existence in GitHub repo: {e}.")
         raise
 
 
@@ -264,7 +265,7 @@ def commit_files_to_branch_github(event: Dict[str, Any], file_paths_with_content
 
         for path, content in file_paths_with_content:
             blob = repo.create_git_blob(content, "utf-8")
-            logger.info(f"Created blob for file '{path}' : {content} : {blob.sha}")
+            logger.info(f"Created Git blob for '{path}' with SHA '{blob.sha}'")
             element = InputGitTreeElement(
                 path=path,
                 mode="100644",
@@ -272,7 +273,7 @@ def commit_files_to_branch_github(event: Dict[str, Any], file_paths_with_content
                 sha=blob.sha,
             )
             tree_elements.append(element)
-        logger.info(f"Prepared tree elements: {tree_elements}")
+        logger.info(f"Prepared Git tree element(s): {tree_elements} for commit")
 
         # Create a new tree
         new_tree = repo.create_git_tree(tree_elements, base_tree=latest_commit.tree)
@@ -283,20 +284,20 @@ def commit_files_to_branch_github(event: Dict[str, Any], file_paths_with_content
         # Point a branch to the new commit
         ref.edit(new_commit.sha)
 
-        logger.info(f"Successfully committed files {file_paths_with_content}")
+        logger.info(f"Successfully committed file(s) {file_paths_with_content} to branch '{branch}'.")
 
 
     except BadCredentialsException as e:
-        logger.error(f"GitHub authentication error: {e}")
+        logger.error(f"GitHub authentication error: {e}.")
         raise
     except UnknownObjectException as e:
-        logger.error(f"GitHub object not found: {e}")
+        logger.error(f"GitHub object not found: {e}.")
         raise
     except GithubException as e:
-        logger.error(f"GitHub API error: {e}")
+        logger.error(f"GitHub API error: {e}.")
         raise
     except Exception as e:
-        logger.error(f"Unexpected error committing files to GitHub repo: {e}")
+        logger.error(f"Unexpected error committing files to GitHub repo: {e}.")
         raise
 
 
@@ -311,16 +312,16 @@ def get_last_commit_sha_github(repo_id_or_name: Union[int, str], pull_number: in
         return pr.head.sha
 
     except BadCredentialsException as e:
-        logger.error(f"GitHub authentication error: {e}")
+        logger.error(f"GitHub authentication error: {e}.")
         raise
     except UnknownObjectException as e:
-        logger.error(f"GitHub object not found: {e}")
+        logger.error(f"GitHub object not found: {e}.")
         raise
     except GithubException as e:
-        logger.error(f"GitHub API error: {e}")
+        logger.error(f"GitHub API error: {e}.")
         raise
     except Exception as e:
-        logger.error(f"Unexpected error getting PR head SHA: {e}")
+        logger.error(f"Unexpected error getting PR head SHA: {e}.")
         raise
 
 
@@ -343,6 +344,6 @@ def get_all_tf_files_from_paths_list_github(
 
         for item in items:
             if item.type == "file" and item.path.endswith(".tf"):
-                logger.info(f"Fetching {item.path} ...")
+                logger.info(f"Fetching Terraform file '{item.path}' from GitHub...")
                 tf_files.append((item.path, item.decoded_content.decode("utf-8")))
     return tf_files

--- a/terraform/modules/lambdas/functions/utilities/vcs/gitlab_functions.py
+++ b/terraform/modules/lambdas/functions/utilities/vcs/gitlab_functions.py
@@ -28,7 +28,7 @@ def _get_gitlab_client() -> gitlab.Gitlab:
         client.version()  # verifies the token and session
     except Exception as e:
         # Do NOT cache a failed session, let the exception propagate
-        logger.error(f"GitLab client verification failed: {e}")
+        logger.error(f"GitLab client verification failed: {e}.")
         raise
 
     return client  # gets cached only if everything above succeeds
@@ -60,26 +60,26 @@ def get_mr_source_branch_name(
 
         logger.debug(
             f"MR {merge_request_id} source branch: '{source_branch}' "
-            f"(project: {project_id_or_path})"
+            f"(project: '{project_id_or_path}')"
         )
 
         return source_branch
 
     except GitlabAuthenticationError as e:
-        logger.error(f"GitLab authentication error while fetching MR: {e}")
+        logger.error(f"GitLab authentication error while fetching MR: {e}.")
         raise
 
     except GitlabGetError as e:
         logger.error(
             f"GitLab API error while fetching MR "
-            f"{merge_request_id} in project '{project_id_or_path}': {e}"
+            f"{merge_request_id} in project '{project_id_or_path}': {e}."
         )
         raise
 
     except Exception as e:
         logger.error(
             f"Unexpected error while getting source branch for MR "
-            f"{merge_request_id}: {e}"
+            f"{merge_request_id}: {e}."
         )
         raise
 
@@ -100,17 +100,17 @@ def add_award_to_note_gitlab(
         note = mr.notes.get(event.get('metadata').get('comment_id'))
         award = note.awardemojis.create({'name': reaction})
 
-        logger.debug(f"Award emoji added: {award.attributes}")
+        logger.debug(f"Added GitLab award emoji: {award.attributes}.")
         return award.attributes
 
     except gitlab.exceptions.GitlabAuthenticationError as e:
-        logger.error(f"GitLab authentication error: {e}")
+        logger.error(f"GitLab authentication error: {e}.")
         raise
     except gitlab.exceptions.GitlabGetError as e:
-        logger.error(f"GitLab get error: {e}")
+        logger.error(f"GitLab get error: {e}.")
         raise
     except Exception as e:
-        logger.error(f"Unexpected error adding award emoji to GitLab note: {e}")
+        logger.error(f"Unexpected error adding award emoji to GitLab note: {e}.")
         raise
 
 
@@ -129,17 +129,17 @@ def post_gitlab_comment(event: Dict[str, Any], comment_text: str) -> Dict[str, A
         mr = project.mergerequests.get(event.get('metadata').get('merge_or_pull_req_id'))
         note = mr.notes.create({'body': comment_text})
 
-        logger.debug(f"Posted comment: {note.attributes}")
+        logger.debug(f"Posted GitLab merge request comment: {note.attributes}.")
         return note.attributes
 
     except gitlab.exceptions.GitlabAuthenticationError as e:
-        logger.error(f"GitLab authentication error: {e}")
+        logger.error(f"GitLab authentication error: {e}.")
         raise
     except gitlab.exceptions.GitlabGetError as e:
-        logger.error(f"GitLab get error: {e}")
+        logger.error(f"GitLab get error: {e}.")
         raise
     except Exception as e:
-        logger.error(f"Unexpected error posting GitLab comment: {e}")
+        logger.error(f"Unexpected error posting GitLab comment: {e}.")
         raise
 
 
@@ -165,9 +165,9 @@ def check_files_exist_in_repo_gitlab(
         gl = _get_gitlab_client()
         project = gl.projects.get(project_id_or_path)
 
-        logger.info(
+        logger.debug(
             f"Batch-checking {len(file_paths)} file(s) in project "
-            f"'{project_id_or_path}' on branch '{branch}'"
+            f"'{project_id_or_path}' on branch '{branch}'."
         )
 
         # Group requested files by directory
@@ -181,7 +181,7 @@ def check_files_exist_in_repo_gitlab(
         missing_files: List[str] = []
 
         for dir_path, expected_files in files_by_dir.items():
-            logger.debug(f"Fetching tree for dir '{dir_path or '/'}'")
+            logger.debug(f"Fetching GitLab repository tree for directory {dir_path or '/'}")
 
             try:
                 tree = project.repository_tree(
@@ -212,22 +212,22 @@ def check_files_exist_in_repo_gitlab(
                     )
 
         if missing_files:
-            logger.info(f"Missing {len(missing_files)} file(s): {missing_files}")
+            logger.warning(f"Some requested file(s) are missing from the repository: {missing_files}")
             return False
 
         logger.info("All files exist in the repository on the specified branch.")
         return True
 
     except GitlabAuthenticationError as e:
-        logger.error(f"GitLab authentication error: {e}")
+        logger.error(f"GitLab authentication error: {e}.")
         raise
 
     except GitlabGetError as e:
-        logger.error(f"GitLab API error: {e}")
+        logger.error(f"GitLab API error: {e}.")
         raise
 
     except Exception as e:
-        logger.error(f"Unexpected error while checking file existence: {e}")
+        logger.error(f"Unexpected error while checking file existence: {e}.")
         raise
 
 
@@ -268,15 +268,15 @@ def commit_files_to_branch_gitlab(
 
         # Use the source branch of the merge request (equivalent to PR head branch)
         branch = mr.source_branch
-        logger.info(
+        logger.debug(
             f"Preparing to commit {len(file_paths_with_content)} file(s) "
-            f"to project '{project_id}' on branch '{branch}'"
+            f"to project '{project_id}' on branch '{branch}'."
         )
 
         # Prepare actions for the commit API
         actions = []
         for path, content in file_paths_with_content:
-            logger.debug(f"Scheduling update for '{path}'")
+            logger.debug(f"Scheduling update for {path}")
             actions.append(
                 {
                     "action": "update",  # assumes files already exist; use "create" if you need to add new ones
@@ -286,7 +286,7 @@ def commit_files_to_branch_gitlab(
             )
 
         if not actions:
-            logger.info("No files provided for commit; skipping commit creation.")
+            logger.warning("No files provided for commit; skipping commit creation.")
             return {}
 
         # Create a single commit with all actions on the MR source branch
@@ -300,21 +300,21 @@ def commit_files_to_branch_gitlab(
 
         logger.info(
             f"Successfully committed {len(file_paths_with_content)} file(s) "
-            f"to branch '{branch}'. Commit ID: {commit.id}"
+            f"to branch '{branch}'. Commit ID: {commit.id}."
         )
         return commit.attributes
 
     except gitlab.exceptions.GitlabAuthenticationError as e:
-        logger.error(f"GitLab authentication error while committing files: {e}")
+        logger.error(f"GitLab authentication error while committing files: {e}.")
         raise
     except gitlab.exceptions.GitlabGetError as e:
-        logger.error(f"GitLab get error while committing files: {e}")
+        logger.error(f"GitLab get error while committing files: {e}.")
         raise
     except gitlab.exceptions.GitlabCreateError as e:
-        logger.error(f"GitLab create error while committing files: {e}")
+        logger.error(f"GitLab create error while committing files: {e}.")
         raise
     except Exception as e:
-        logger.error(f"Unexpected error committing files to GitLab repo: {e}")
+        logger.error(f"Unexpected error committing files to GitLab repo: {e}.")
         raise
 
 
@@ -332,7 +332,7 @@ def get_all_tf_files_from_paths_list_gitlab(
         items = project.repository_tree(path=target_dir, ref=event.get('metadata').get('source_branch'))
         for item in items:
             if item['type'] == 'blob' and item['name'].endswith('.tf'):
-                logger.info(f"Fetching {item['path']} ...")
+                logger.info(f"Fetching Terraform file '{item['path']}' from GitLab...")
                 file = project.files.get(file_path=item['path'], ref=event.get('metadata').get('source_branch'))
                 # Decode base64 content to text string (assume UTF-8)
                 content_text = base64.b64decode(file.content).decode('utf-8')


### PR DESCRIPTION
## Summary

This PR cleans up logging across the Lambda handlers and shared utilities.

The main goal is to make INFO logs less noisy, keep detailed diagnostics in DEBUG, and standardize log wording across GitHub/GitLab, auth, prompt, and handler flows.

## Changes

- standardized log messages for consistency
- moved verbose/internal logs from INFO to DEBUG
- removed noisy content dumps from normal execution paths
- adjusted a few log levels to better match severity
- switched to a named logger (`braintf`) instead of the root logger
- updated unit tests for the revised log output
- tightened the return type for `get_file_content_with_metadata_from_s3`

## Notes for reviewers

- this is intended to be a logging-focused change, not a functional behavior change
- the main review areas are log level choices, message wording, and whether any useful operational signal was removed from INFO logs
- tests were updated only where they asserted exact log messages
