### PR TITLE
refactor: EPMCACMAWS-483 Implement OpenAI library instead requests library

### DIFF
--- a/terraform/modules/lambdas/functions/tests/conftest.py
+++ b/terraform/modules/lambdas/functions/tests/conftest.py
@@ -19,7 +19,7 @@ def patched_environment(monkeypatch):
     monkeypatch.setenv("ARTIFACTS_PATH", "artifacts")
     monkeypatch.setenv("AI_API_TOKEN_NAME", "token")
     monkeypatch.setenv("LLM_MODEL", "gpt-3.5-turbo")
-    monkeypatch.setenv("AI_API_ENDPOINT", "https://ai.example.com")
+    monkeypatch.setenv("AI_API_ENDPOINT", "https://api.testopenai.com/v1")
     monkeypatch.setenv("DYNAMODB_TABLE_NAME", "table_name")
     monkeypatch.setenv("LOG_LEVEL", "DEBUG")
     monkeypatch.setenv("RAG_ENABLED", "true")

--- a/terraform/modules/lambdas/functions/tests/utilities/ai/test_chat_completions.py
+++ b/terraform/modules/lambdas/functions/tests/utilities/ai/test_chat_completions.py
@@ -192,5 +192,5 @@ def test_generate_response_ai_raises_when_response_choices_missing(
 
     messages = [user_message("x")]
 
-    with pytest.raises(IndexError):
+    with pytest.raises(ValueError, match="AI API response is missing choices."):
         generate_response_ai(messages)

--- a/terraform/modules/lambdas/functions/tests/utilities/ai/test_chat_completions.py
+++ b/terraform/modules/lambdas/functions/tests/utilities/ai/test_chat_completions.py
@@ -1,15 +1,42 @@
-class FakeResponse:
-    def __init__(self, status_code=200, json_data=None, raise_exc=None):
-        self.status_code = status_code
-        self._json_data = json_data or {}
-        self._raise_exc = raise_exc
+import logging
+from types import SimpleNamespace
+from typing import Any
 
-    def raise_for_status(self):
-        if self._raise_exc:
-            raise self._raise_exc
+import httpx
+import pytest
+from openai.types.chat import ChatCompletionUserMessageParam
 
-    def json(self):
-        return self._json_data
+
+class FakeOpenAIResponse:
+    def __init__(self, data: dict[str, Any] | None = None):
+        self._data = data or {}
+        self.choices = []
+
+        for choice_data in self._data.get("choices", []):
+            message_data = choice_data.get("message")
+            message = None
+            if message_data is not None:
+                message = SimpleNamespace(content=message_data.get("content"))
+            self.choices.append(SimpleNamespace(message=message))
+
+        usage_data = self._data.get("usage")
+        self.usage = SimpleNamespace(**usage_data) if isinstance(usage_data, dict) else None
+
+
+def user_message(content: str) -> ChatCompletionUserMessageParam:
+    return {"role": "user", "content": content}
+
+
+def fake_openai_client(fake_create):
+    def fake_openai(**kwargs: Any):
+        assert kwargs["max_retries"] == 0
+        return SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(create=fake_create),
+            ),
+        )
+
+    return fake_openai
 
 
 def test_generate_response_ai_success(patched_environment, ssm_setup, monkeypatch):
@@ -18,102 +45,152 @@ def test_generate_response_ai_success(patched_environment, ssm_setup, monkeypatc
 
     captured = {}
 
-    def fake_post(url, headers, json, timeout):
-        captured["url"] = url
-        captured["headers"] = headers
-        captured["json"] = json
-        captured["timeout"] = timeout
-        return FakeResponse(
-            status_code=200,
-            json_data={
+    def fake_create(**kwargs):
+        captured["create_kwargs"] = kwargs
+        return FakeOpenAIResponse(
+            {
                 "choices": [{"message": {"content": " fixed response  "}}],
                 "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
-            },
+            }
         )
 
-    monkeypatch.setattr("utilities.ai.chat_completions.requests.post", fake_post)
+    def fake_openai(**kwargs):
+        captured["client_kwargs"] = kwargs
+        return SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(create=fake_create),
+            ),
+        )
 
-    result = generate_response_ai([{"role": "user", "content": "hello"}])
+    monkeypatch.setattr("utilities.ai.chat_completions.OpenAI", fake_openai)
 
-    assert captured["url"] == "https://ai.example.com"
-    assert captured["headers"]["Api-Key"] == "token"
-    assert captured["json"]["model"] == "gpt-3.5-turbo"
-    assert captured["json"]["messages"][0] == {"role": "system", "content": SYSTEM_ROLE_MESSAGE}
-    assert captured["json"]["messages"][1] == {"role": "user", "content": "hello"}
-    assert captured["timeout"] == (361, 361)
+    result = generate_response_ai([user_message("hello")])
+
+    assert captured["client_kwargs"]["base_url"] == "https://api.testopenai.com/v1"
+    assert captured["client_kwargs"]["api_key"] == "token"
+    assert captured["client_kwargs"]["max_retries"] == 0
+    assert captured["create_kwargs"]["model"] == "gpt-3.5-turbo"
+    assert captured["create_kwargs"]["messages"][0] == {"role": "system", "content": SYSTEM_ROLE_MESSAGE}
+    assert captured["create_kwargs"]["messages"][1] == {"role": "user", "content": "hello"}
+    assert captured["create_kwargs"]["temperature"] == 0.4
     assert result == {
-        "message": "fixed response\n",
+        "message": " fixed response  ",
         "tokens": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
     }
 
+
 def test_generate_response_ai_retries_then_success(patched_environment, ssm_setup, monkeypatch):
+    from openai import APITimeoutError
+
     from utilities.ai.chat_completions import generate_response_ai
 
+    request = httpx.Request("POST", "https://api.testopenai.com/v1")
     responses = [
-        FakeResponse(status_code=500),
-        FakeResponse(
-            status_code=200,
-            json_data={
+        APITimeoutError(request=request),
+        FakeOpenAIResponse(
+            {
                 "choices": [{"message": {"content": "ok"}}],
                 "usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3},
-            },
+            }
         ),
     ]
-    post_calls = {"count": 0}
+    create_calls = {"count": 0}
     sleeps = []
 
-    def fake_post(*args, **kwargs):
-        idx = post_calls["count"]
-        post_calls["count"] += 1
-        return responses[idx]
+    def fake_create(**kwargs: Any):
+        assert kwargs["temperature"] == 0.4
+        idx = create_calls["count"]
+        create_calls["count"] += 1
+        response = responses[idx]
+        if isinstance(response, Exception):
+            raise response
+        return response
 
-    monkeypatch.setattr("utilities.ai.chat_completions.requests.post", fake_post)
+    monkeypatch.setattr(
+        "utilities.ai.chat_completions.OpenAI",
+        fake_openai_client(fake_create),
+    )
     monkeypatch.setattr("utilities.ai.chat_completions.time.sleep", lambda s: sleeps.append(s))
 
-    result = generate_response_ai([{"role": "user", "content": "x"}], retries=3)
+    result = generate_response_ai([user_message("x")], retries=3)
 
-    assert post_calls["count"] == 2
+    assert create_calls["count"] == 2
     assert sleeps == [1]
-    assert result["message"] == "ok\n"
+    assert result["message"] == "ok"
     assert result["tokens"]["total_tokens"] == 3
 
 
-def test_generate_response_ai_raises_after_retries(patched_environment, ssm_setup, monkeypatch):
-    import requests
+def test_generate_response_ai_raises_after_retries(patched_environment, ssm_setup, monkeypatch, caplog):
+    from openai import APITimeoutError
+
     from utilities.ai.chat_completions import generate_response_ai
 
     sleeps = []
-    errors = []
+    create_calls = {"count": 0}
+    request = httpx.Request("POST", "https://api.testopenai.com/v1")
 
-    def fake_post(*args, **kwargs):
-        raise requests.Timeout("timeout")
-
-    monkeypatch.setattr("utilities.ai.chat_completions.requests.post", fake_post)
-    monkeypatch.setattr("utilities.ai.chat_completions.time.sleep", lambda s: sleeps.append(s))
-    monkeypatch.setattr("utilities.ai.chat_completions.logger.error", lambda msg: errors.append(msg))
-
-    try:
-        generate_response_ai([{"role": "user", "content": "x"}], retries=2)
-        assert False, "Expected timeout to be raised"
-    except requests.Timeout:
-        pass
-
-    assert sleeps == [1, 2]
-    assert len(errors) == 1
-    assert "failed after 2 retries" in errors[0]
-
-
-def test_generate_response_ai_defaults_when_response_fields_missing(patched_environment, ssm_setup, monkeypatch):
-    from utilities.ai.chat_completions import generate_response_ai
+    def fake_create(**kwargs: Any):
+        assert kwargs["temperature"] == 0.4
+        create_calls["count"] += 1
+        raise APITimeoutError(request=request)
 
     monkeypatch.setattr(
-        "utilities.ai.chat_completions.requests.post",
-        lambda *args, **kwargs: FakeResponse(status_code=200, json_data={}),
+        "utilities.ai.chat_completions.OpenAI",
+        fake_openai_client(fake_create),
+    )
+    monkeypatch.setattr("utilities.ai.chat_completions.time.sleep", lambda s: sleeps.append(s))
+
+    caplog.set_level(logging.ERROR, logger="braintf")
+
+    messages = [user_message("x")]
+
+    with pytest.raises(APITimeoutError):
+        generate_response_ai(messages, retries=2)
+
+    assert create_calls["count"] == 3
+    assert sleeps == [1, 2]
+    assert "failed after 2 retries" in caplog.text
+
+
+def test_generate_response_ai_defaults_when_usage_or_content_missing(patched_environment, ssm_setup, monkeypatch):
+    from utilities.ai.chat_completions import generate_response_ai
+
+    def fake_create(**kwargs: Any):
+        assert kwargs["temperature"] == 0.4
+        return FakeOpenAIResponse(
+            {"choices": [{"message": {"content": None}}]},
+        )
+
+    monkeypatch.setattr(
+        "utilities.ai.chat_completions.OpenAI",
+        fake_openai_client(fake_create),
     )
 
-    result = generate_response_ai([{"role": "user", "content": "x"}])
+    result = generate_response_ai([user_message("x")])
 
     assert result == {
-        "message": "\n",
+        "message": "",
         "tokens": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
     }
+
+
+def test_generate_response_ai_raises_when_response_choices_missing(
+        patched_environment,
+        ssm_setup,
+        monkeypatch,
+):
+    from utilities.ai.chat_completions import generate_response_ai
+
+    def fake_create(**kwargs: Any):
+        assert kwargs["temperature"] == 0.4
+        return FakeOpenAIResponse()
+
+    monkeypatch.setattr(
+        "utilities.ai.chat_completions.OpenAI",
+        fake_openai_client(fake_create),
+    )
+
+    messages = [user_message("x")]
+
+    with pytest.raises(IndexError):
+        generate_response_ai(messages)

--- a/terraform/modules/lambdas/functions/utilities/ai/chat_completions.py
+++ b/terraform/modules/lambdas/functions/utilities/ai/chat_completions.py
@@ -12,32 +12,28 @@ from utilities.messages import SYSTEM_ROLE_MESSAGE
 
 def generate_response_ai(messages: list[ChatCompletionMessageParam], retries: int = 3) -> dict:
     """
-    Generates a response from an AI model based on the provided messages and retry logic.
-
-    This function sends a request to the AI API to generate a completion for the given chat
-    messages. It includes customizable retry logic to handle transient errors during the
-    API communication.
+    Generates a response from an AI system by sending a list of message prompts and processing the
+    response. Handles retries in case of connection or server errors with an exponential backoff
+    strategy.
 
     Args:
-        messages (list[ChatCompletionMessageParam]): A list of message parameters to be sent
-            to the AI API for generating a response. These typically include user and system
-            prompts.
-        retries (int, optional): The maximum number of retry attempts to make in case of API
-            errors. Defaults to 3.
+        messages (list[ChatCompletionMessageParam]): A list of message objects to be sent as prompts
+            to the AI system.
+        retries (int, optional): The number of retry attempts to make in case of errors. Defaults to 3.
 
     Returns:
-        dict: A dictionary containing the AI-generated message and token usage details. The
-            keys are:
-            - "message": The generated message content (str).
-            - "tokens": A dictionary with token usage details, including:
-                - "prompt_tokens" (int): Number of tokens used for the prompt.
-                - "completion_tokens" (int): Number of tokens used for the completion.
-                - "total_tokens" (int): Total tokens consumed.
+        dict: A dictionary containing the AI's response message and token usage details:
+            - 'message': The content of the response as a string.
+            - 'tokens': A nested dictionary with token usage details:
+                - 'prompt_tokens': The number of tokens used in the input prompt.
+                - 'completion_tokens': The number of tokens used in the generated completion.
+                - 'total_tokens': The combined total of prompt and completion tokens.
 
     Raises:
-        APITimeoutError: If the API request times out and exceeds the allowed retry attempts.
+        ValueError: If the AI response contains no choices or is improperly formatted.
+        APITimeoutError: If the API request times out.
         APIConnectionError: If there is a connection issue with the API.
-        APIStatusError: If the API returns an invalid or error status code after retries.
+        APIStatusError: If the API returns an unexpected status code.
     """
     system_role_message: ChatCompletionSystemMessageParam = {
         "role": "system",
@@ -75,6 +71,9 @@ def generate_response_ai(messages: list[ChatCompletionMessageParam], retries: in
             wait = 2 ** (attempt - 1)
             logger.warning(f"AI API error: {e} — retry {attempt}/{retries} in {wait}s")
             time.sleep(wait)
+
+    if not response.choices:
+        raise ValueError("AI API response is missing choices.")
 
     content = response.choices[0].message.content or ''
 

--- a/terraform/modules/lambdas/functions/utilities/ai/chat_completions.py
+++ b/terraform/modules/lambdas/functions/utilities/ai/chat_completions.py
@@ -1,109 +1,94 @@
 import time
 
-import requests
+from openai import APIConnectionError, APIStatusError, APITimeoutError, OpenAI
+from openai.types import CompletionUsage
+from openai.types.chat import (ChatCompletionMessageParam,
+                               ChatCompletionSystemMessageParam)
 
 from config import config
 from utilities.logger import logger
 from utilities.messages import SYSTEM_ROLE_MESSAGE
 
 
-def generate_response_ai(messages: list, retries: int = 3) -> dict:
+def generate_response_ai(messages: list[ChatCompletionMessageParam], retries: int = 3) -> dict:
     """
-    Generates a response from an AI model by sending a set of messages to the AI API,
-    handles retries on certain types of errors, and parses the response to return
-    useful message content and token usage information.
+    Generates a response from an AI model based on the provided messages and retry logic.
+
+    This function sends a request to the AI API to generate a completion for the given chat
+    messages. It includes customizable retry logic to handle transient errors during the
+    API communication.
 
     Args:
-        messages (list): A list of message dictionaries to send to the AI API. Each dictionary
-            should have a "role" (e.g., "user", "assistant") and "content" (the text of the
-            message).
-        retries (int): The maximum number of retries allowed in case of API request failures.
-            Defaults to 3.
+        messages (list[ChatCompletionMessageParam]): A list of message parameters to be sent
+            to the AI API for generating a response. These typically include user and system
+            prompts.
+        retries (int, optional): The maximum number of retry attempts to make in case of API
+            errors. Defaults to 3.
 
     Returns:
-        dict: A dictionary containing:
-            - "message" (str): The AI-generated response content.
-            - "tokens" (dict): A dictionary detailing token usage, with the following keys:
-                - "prompt_tokens" (int): The number of tokens used for the input messages.
-                - "completion_tokens" (int): The number of tokens generated for the output.
-                - "total_tokens" (int): The total number of tokens used (sum of prompt and
-                  completion tokens).
+        dict: A dictionary containing the AI-generated message and token usage details. The
+            keys are:
+            - "message": The generated message content (str).
+            - "tokens": A dictionary with token usage details, including:
+                - "prompt_tokens" (int): Number of tokens used for the prompt.
+                - "completion_tokens" (int): Number of tokens used for the completion.
+                - "total_tokens" (int): Total tokens consumed.
 
     Raises:
-        requests.Timeout: If the API request times out and the retry limit is exceeded.
-        requests.ConnectionError: If the API connection fails and the retry limit is exceeded.
-        requests.HTTPError: If a server-side (5xx) or client-side (4xx) error occurs and the
-            retry limit is exceeded.
+        APITimeoutError: If the API request times out and exceeds the allowed retry attempts.
+        APIConnectionError: If there is a connection issue with the API.
+        APIStatusError: If the API returns an invalid or error status code after retries.
     """
-    messages = [{"role": "system", "content": SYSTEM_ROLE_MESSAGE}] + messages
-    headers = {
-        "Content-Type": "application/json",
-        "Api-Key": config.ai_api_token
+    system_role_message: ChatCompletionSystemMessageParam = {
+        "role": "system",
+        "content": SYSTEM_ROLE_MESSAGE
     }
+    request_messages: list[ChatCompletionMessageParam] = [system_role_message] + messages
 
-    payload = {
-        "model": config.llm_model,
-        "messages": messages,
-        "temperature": 0.4
-    }
+    client = OpenAI(
+        base_url=config.ai_api_endpoint,
+        api_key=config.ai_api_token,
+        max_retries=0,
+    )
 
     attempt = 0
 
     while True:
         logger.debug(f"Requesting AI API with baseurl: {config.ai_api_endpoint}")
         try:
-            resp = requests.post(
-                config.ai_api_endpoint,
-                headers=headers,
-                json=payload,
-                timeout=config.default_timeout
+            response = client.chat.completions.create(
+                model=config.llm_model,
+                messages=request_messages,
+                temperature=0.4,
             )
 
-            # Retry on 5xx responses
-            if 500 <= resp.status_code < 600:
-                raise requests.HTTPError(f"Server error: {resp.status_code}", response=resp)
+            break
 
-            resp.raise_for_status()
-            break  # success → exit retry loop
-
-        except (requests.Timeout,
-                requests.ConnectionError,
-                requests.HTTPError) as e:
+        except (APITimeoutError, APIConnectionError, APIStatusError) as e:
 
             attempt += 1
 
             if attempt > retries:
-                logger.error(f"AI API request failed after {retries} retries: {e}")
+                logger.error(f"AI API request failed after {retries} retries: {e}.")
                 raise
 
             wait = 2 ** (attempt - 1)
             logger.warning(f"AI API error: {e} — retry {attempt}/{retries} in {wait}s")
             time.sleep(wait)
 
-    # Parse JSON once
-    data_json = resp.json()
+    content = response.choices[0].message.content or ''
 
-    # Safely extract content
-    message = (
-            data_json.get("choices", [{}])[0]
-            .get("message", {})
-            .get("content", "")
-            .strip() + "\n"
-    )
-
-    usage = data_json.get("usage", {})
-    prompt_tokens = usage.get("prompt_tokens", 0)
-    completion_tokens = usage.get("completion_tokens", 0)
-    total_tokens = usage.get("total_tokens", 0)
+    usage: CompletionUsage | None = response.usage
+    prompt_tokens = usage.prompt_tokens if usage else 0
+    completion_tokens = usage.completion_tokens if usage else 0
+    total_tokens = usage.total_tokens if usage else 0
 
     logger.info(
-        f"Prompt tokens: {prompt_tokens}, "
-        f"Completion tokens: {completion_tokens}, "
-        f"Total tokens: {total_tokens}"
+        f"AI API used prompt tokens: {prompt_tokens}, completion tokens: {completion_tokens}, total tokens: {total_tokens}"
     )
 
     return {
-        "message": message,
+        "message": content,
         "tokens": {
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,


### PR DESCRIPTION
## Summary

Replaces the custom `requests.post` implementation for AI chat completions with the official OpenAI Python client.

## Changes

- Use `OpenAI` client with configured `base_url`, `api_key`, and `max_retries=0`.
- Send chat completion requests via `client.chat.completions.create(...)`.
- Preserve existing application-level retry/backoff behavior for:
  - `APITimeoutError`
  - `APIConnectionError`
  - `APIStatusError`
- Parse generated content and token usage from OpenAI SDK response objects.
- Add OpenAI chat completion typing for request messages and usage handling.
- Update tests to mock the OpenAI client instead of raw HTTP requests.
- Update test AI endpoint fixture to use an OpenAI-compatible `/v1` base URL.

## Notes

- `openai==2.32.0` is already present in both runtime and test requirements.
- Response content is now returned as provided by the SDK, without stripping whitespace or appending a trailing newline.
- OpenAI SDK retry behavior is disabled so the existing explicit retry logic remains the single retry mechanism.