### PR TITLE
fix: EPMCACMAWS-474 Fix Lambda function behaviour when the VCS token variable is updated

### DIFF
--- a/terraform/modules/lambdas/functions/config.py
+++ b/terraform/modules/lambdas/functions/config.py
@@ -49,30 +49,31 @@ class _ConfigLambda:
         TTL_DELTA_DAYS: Adjusts the TTL offset in days.
 
     Notes:
-        * URLs must include an explicit scheme (``http`` or ``https``) to pass validation.
+        * URLs must use the ``https`` scheme to pass validation.
         * Boolean flags accept ``true``, ``1``, or ``yes`` (case-insensitive) as truthy.
-        * Secrets retrieved from SSM are memoized via ``functools.cached_property`` to
-          minimize repeated network calls.
+        * VCS tokens, webhook secrets, and AI API tokens are loaded from SSM on
+          each access.
+          Other expensive AWS lookups may still be memoized where appropriate.
         * Validation raises ``ValueError`` with descriptive messages whenever required
           configuration is missing or malformed.
     """
 
     def __init__(self) -> None:
-        self.default_timeout: tuple[float, float] = (361, 361)
+        self.default_timeout: tuple[float | int, float | int] = (361, 361)
         self.boto3_config: Config = Config(connect_timeout=self.default_timeout[0],
                                            read_timeout=self.default_timeout[1])
 
         # Load environment variables
         self.vcs_provider: str = os.environ.get("VCS_PROVIDER", "github")
-        self.vcs_token_name: str = os.environ.get('VCS_TOKEN_NAME')
-        self.vcs_api_endpoint: str = os.environ.get('VCS_API_ENDPOINT')
-        self.webhook_secret_name: str = os.environ.get('WEBHOOK_SECRET_NAME')
-        self.artifacts_bucket: str = os.environ.get('ARTIFACTS_BUCKET')
+        self.vcs_token_name: str | None = os.environ.get('VCS_TOKEN_NAME')
+        self.vcs_api_endpoint: str | None = os.environ.get('VCS_API_ENDPOINT')
+        self.webhook_secret_name: str | None = os.environ.get('WEBHOOK_SECRET_NAME')
+        self.artifacts_bucket: str | None = os.environ.get('ARTIFACTS_BUCKET')
         self.path_to_artifacts: str = os.environ.get('ARTIFACTS_PATH', 'artifacts')
-        self.ai_api_token_name: str = os.environ.get('AI_API_TOKEN_NAME')
-        self.llm_model: str = os.environ.get("LLM_MODEL")
-        self.ai_api_endpoint: str = os.environ.get("AI_API_ENDPOINT")
-        self.table_name: str = os.environ.get("DYNAMODB_TABLE_NAME")
+        self.ai_api_token_name: str | None = os.environ.get('AI_API_TOKEN_NAME')
+        self.llm_model: str | None = os.environ.get("LLM_MODEL")
+        self.ai_api_endpoint: str | None = os.environ.get("AI_API_ENDPOINT")
+        self.table_name: str | None = os.environ.get("DYNAMODB_TABLE_NAME")
         self.log_level: str = os.environ.get("LOG_LEVEL", "INFO").upper()
         self.rag_enabled: bool = os.environ.get("RAG_ENABLED", "False").lower() in ("true", "1", "yes")
         self.ttl_delta_days: int = int(os.environ.get("TTL_DELTA_DAYS", 30))
@@ -110,9 +111,9 @@ class _ConfigLambda:
         if not self.vcs_api_endpoint:
             raise ValueError("VCS_API_ENDPOINT environment variable is required")
 
-        if not self.vcs_api_endpoint.startswith(('http://', 'https://')):
+        if not self.vcs_api_endpoint.startswith('https://'):  # :noqa
             raise ValueError(
-                f"VCS_API_ENDPOINT must be a valid URL: {self.vcs_api_endpoint}"
+                f"VCS_API_ENDPOINT must start with https://: {self.vcs_api_endpoint}"
             )
         if self.vcs_api_endpoint.endswith(self.git_api_endpoint_version):
             raise ValueError(
@@ -142,9 +143,9 @@ class _ConfigLambda:
         if not self.ai_api_endpoint:
             raise ValueError("AI_API_ENDPOINT environment variable is required")
 
-        if not self.ai_api_endpoint.startswith(('http://', 'https://')):
+        if not self.ai_api_endpoint.startswith('https://'):
             raise ValueError(
-                f"AI_API_ENDPOINT must be a valid URL: {self.ai_api_endpoint}"
+                f"AI_API_ENDPOINT must start with https://: {self.ai_api_endpoint}"
             )
 
     def _validate_dynamodb_config(self) -> None:
@@ -161,12 +162,11 @@ class _ConfigLambda:
                 f"Must be one of: {', '.join(valid_log_levels)}"
             )
 
-    @cached_property
+    @property
     def vcs_api_token(self) -> str:
         """
-        Provides a cached property to retrieve the VCS API token securely from
-        AWS SSM parameter store with decryption enabled. This avoids repeated
-        calls to fetch the token and improves performance by caching the result.
+        Retrieves the VCS API token securely from AWS SSM parameter store with
+        decryption enabled.
 
         Returns:
             str: The decrypted VCS API token.
@@ -183,7 +183,7 @@ class _ConfigLambda:
         )
         return response['Parameter']['Value']
 
-    @cached_property
+    @property
     def webhook_secret(self) -> str:
         ssm = boto3.client('ssm', config=self.boto3_config)
         response: Dict[str, Any] = ssm.get_parameter(
@@ -192,7 +192,7 @@ class _ConfigLambda:
         )
         return response['Parameter']['Value']
 
-    @cached_property
+    @property
     def ai_api_token(self) -> str:
         ssm = boto3.client('ssm', config=self.boto3_config)
         response: Dict[str, Any] = ssm.get_parameter(

--- a/terraform/modules/lambdas/functions/config.py
+++ b/terraform/modules/lambdas/functions/config.py
@@ -59,7 +59,7 @@ class _ConfigLambda:
     """
 
     def __init__(self) -> None:
-        self.default_timeout: tuple[float | int, float | int] = (361, 361)
+        self.default_timeout: tuple[float, float] = (361, 361)
         self.boto3_config: Config = Config(connect_timeout=self.default_timeout[0],
                                            read_timeout=self.default_timeout[1])
 

--- a/terraform/modules/lambdas/functions/config.py
+++ b/terraform/modules/lambdas/functions/config.py
@@ -111,7 +111,7 @@ class _ConfigLambda:
         if not self.vcs_api_endpoint:
             raise ValueError("VCS_API_ENDPOINT environment variable is required")
 
-        if not self.vcs_api_endpoint.startswith('https://'):  # :noqa
+        if not self.vcs_api_endpoint.startswith('https://'):
             raise ValueError(
                 f"VCS_API_ENDPOINT must start with https://: {self.vcs_api_endpoint}"
             )

--- a/terraform/modules/lambdas/functions/tests/conftest.py
+++ b/terraform/modules/lambdas/functions/tests/conftest.py
@@ -61,6 +61,16 @@ def ssm_setup():
             Type="String",
         )
         client.put_parameter(
+            Name="x-github-token",
+            Value=EXPECTED_TOKEN_GITHUB,
+            Type="String",
+        )
+        client.put_parameter(
+            Name="webhook_secret",
+            Value=EXPECTED_TOKEN_GITLAB,
+            Type="String",
+        )
+        client.put_parameter(
             Name="token",
             Value="token",
             Type="String",
@@ -79,56 +89,43 @@ def expected_token_github():
 
 
 @pytest.fixture
-def patched_config_gitlab(patched_environment, expected_token_gitlab):
+def patched_config_gitlab(patched_environment, ssm_setup):
     from config import config
 
-    # Patch the cached_property `webhook_secret`
-    new_object = type(config)
-    patched_environment.setattr(
-        new_object,
-        "webhook_secret",
-        property(lambda self: expected_token_gitlab),
-    )
+    patched_environment.setattr(config, "vcs_provider", "gitlab")
+    patched_environment.setattr(config, "vcs_token_name", "x-gitlab-token")
     return patched_environment
 
 
 @pytest.fixture
-def patched_config_github(patched_environment, expected_token_github):
+def patched_config_github(patched_environment, ssm_setup, expected_token_github):
     from config import config
 
-    # Patch the cached_property `webhook_secret`
-    new_object = type(config)
-
-    patched_environment.setattr(
-        new_object,
-        "webhook_secret",
-        property(lambda self: expected_token_github),
+    boto3.client("ssm").put_parameter(
+        Name="webhook_secret",
+        Value=expected_token_github,
+        Type="String",
+        Overwrite=True,
     )
 
-    patched_environment.setattr(
-        "utilities.auth.config.vcs_provider",
-        "github"
-    )
+    patched_environment.setattr(config, "vcs_provider", "github")
+    patched_environment.setattr(config, "vcs_token_name", "x-github-token")
     return patched_environment
 
 
 @pytest.fixture
-def patched_config_wrong_vcs(patched_environment, expected_token_github):
+def patched_config_wrong_vcs(patched_environment, ssm_setup, expected_token_github):
     from config import config
 
-    # Patch the cached_property `webhook_secret`
-    new_object = type(config)
-
-    patched_environment.setattr(
-        new_object,
-        "webhook_secret",
-        property(lambda self: expected_token_github),
+    boto3.client("ssm").put_parameter(
+        Name="webhook_secret",
+        Value=expected_token_github,
+        Type="String",
+        Overwrite=True,
     )
 
-    patched_environment.setattr(
-        "utilities.auth.config.vcs_provider",
-        "bitbucket"
-    )
+    patched_environment.setattr(config, "vcs_provider", "bitbucket")
+    patched_environment.setattr(config, "vcs_token_name", "x-github-token")
     return patched_environment
 
 

--- a/terraform/modules/lambdas/functions/tests/conftest.py
+++ b/terraform/modules/lambdas/functions/tests/conftest.py
@@ -89,8 +89,15 @@ def expected_token_github():
 
 
 @pytest.fixture
-def patched_config_gitlab(patched_environment, ssm_setup):
+def patched_config_gitlab(patched_environment, ssm_setup, expected_token_gitlab):
     from config import config
+
+    boto3.client("ssm").put_parameter(
+        Name="webhook_secret",
+        Value=expected_token_gitlab,
+        Type="String",
+        Overwrite=True,
+    )
 
     patched_environment.setattr(config, "vcs_provider", "gitlab")
     patched_environment.setattr(config, "vcs_token_name", "x-gitlab-token")

--- a/terraform/modules/lambdas/functions/tests/utilities/vcs/test_github_functions.py
+++ b/terraform/modules/lambdas/functions/tests/utilities/vcs/test_github_functions.py
@@ -152,7 +152,7 @@ def test_get_github_client_success(patched_config_gitlab, ssm_setup, mock_github
     _get_github_client.cache_clear()
     mock_gh_class, _ = mock_github
 
-    client = _get_github_client()
+    client = _get_github_client(expected_token_gitlab)
 
     assert client == mock_gh_class.instance
     assert mock_gh_class.call_count == 1
@@ -161,7 +161,7 @@ def test_get_github_client_success(patched_config_gitlab, ssm_setup, mock_github
     assert mock_gh_class.instance.get_user_called == 1
 
 
-def test_get_github_client_failure(patched_config_gitlab, mock_github, monkeypatch):
+def test_get_github_client_failure(patched_config_gitlab, mock_github, monkeypatch, expected_token_gitlab):
     from utilities.vcs.github_functions import _get_github_client
     _get_github_client.cache_clear()
     mock_gh_class, _ = mock_github
@@ -171,22 +171,23 @@ def test_get_github_client_failure(patched_config_gitlab, mock_github, monkeypat
     monkeypatch.setattr("utilities.vcs.github_functions.logger", mock_logger)
 
     with pytest.raises(Exception, match="Verification failed"):
-        _get_github_client()
+        _get_github_client(expected_token_gitlab)
 
     assert mock_logger.error_called == 1
     assert mock_gh_class.instance.get_user_called == 1
 
 
-def test_get_github_client_caching(patched_config_gitlab, mock_github):
+def test_get_github_client_caching(patched_config_gitlab, mock_github, expected_token_gitlab):
     from utilities.vcs.github_functions import _get_github_client
     _get_github_client.cache_clear()
     mock_gh_class, _ = mock_github
 
-    client1 = _get_github_client()
-    client2 = _get_github_client()
+    client1 = _get_github_client(expected_token_gitlab)
+    client2 = _get_github_client(expected_token_gitlab)
+    _get_github_client("rotated-token")
 
     assert client1 is client2
-    assert mock_gh_class.call_count == 1
+    assert mock_gh_class.call_count == 2
 
 
 def test_post_pr_comment_github_success(patched_config_gitlab, ssm_setup, mock_github):

--- a/terraform/modules/lambdas/functions/tests/utilities/vcs/test_gitlab_functions.py
+++ b/terraform/modules/lambdas/functions/tests/utilities/vcs/test_gitlab_functions.py
@@ -177,7 +177,7 @@ def test_get_gitlab_client_success(patched_config_gitlab, ssm_setup, mock_gitlab
     from utilities.vcs.gitlab_functions import _get_gitlab_client
     _get_gitlab_client.cache_clear()
 
-    client = _get_gitlab_client()
+    client = _get_gitlab_client(expected_token_gitlab)
 
     assert client == mock_gitlab.instance
     assert mock_gitlab.call_count == 1
@@ -188,17 +188,17 @@ def test_get_gitlab_client_success(patched_config_gitlab, ssm_setup, mock_gitlab
     assert mock_gitlab.instance.auth_called == 1
     assert mock_gitlab.instance.version_called == 1
 
-def test_get_gitlab_client_auth_failure(patched_config_gitlab, mock_gitlab):
+def test_get_gitlab_client_auth_failure(patched_config_gitlab, mock_gitlab, expected_token_gitlab):
     from utilities.vcs.gitlab_functions import _get_gitlab_client
     _get_gitlab_client.cache_clear()
     mock_gitlab.instance.side_effect_auth = gitlab.GitlabAuthenticationError("Auth failed")
 
     with pytest.raises(gitlab.GitlabAuthenticationError, match="Auth failed"):
-        _get_gitlab_client()
+        _get_gitlab_client(expected_token_gitlab)
 
     assert mock_gitlab.instance.auth_called == 1
 
-def test_get_gitlab_client_version_failure(patched_config_gitlab, mock_gitlab,monkeypatch):
+def test_get_gitlab_client_version_failure(patched_config_gitlab, mock_gitlab, monkeypatch, expected_token_gitlab):
     from utilities.vcs.gitlab_functions import _get_gitlab_client
     _get_gitlab_client.cache_clear()
     mock_gitlab.instance.side_effect_version = Exception("Version check failed")
@@ -207,21 +207,22 @@ def test_get_gitlab_client_version_failure(patched_config_gitlab, mock_gitlab,mo
     monkeypatch.setattr("utilities.vcs.gitlab_functions.logger", mock_logger)
 
     with pytest.raises(Exception, match="Version check failed"):
-        _get_gitlab_client()
+        _get_gitlab_client(expected_token_gitlab)
 
     assert mock_logger.error_called >= 1
     assert mock_gitlab.instance.auth_called == 1
     assert mock_gitlab.instance.version_called == 1
 
-def test_get_gitlab_client_caching(patched_config_gitlab, mock_gitlab):
+def test_get_gitlab_client_caching(patched_config_gitlab, mock_gitlab, expected_token_gitlab):
     from utilities.vcs.gitlab_functions import _get_gitlab_client
     _get_gitlab_client.cache_clear()
 
-    client1 = _get_gitlab_client()
-    client2 = _get_gitlab_client()
+    client1 = _get_gitlab_client(expected_token_gitlab)
+    client2 = _get_gitlab_client(expected_token_gitlab)
+    _get_gitlab_client("rotated-token")
 
     assert client1 is client2
-    assert mock_gitlab.call_count == 1
+    assert mock_gitlab.call_count == 2
 
 
 def test_post_gitlab_comment_success(patched_config_gitlab, ssm_setup, mock_gitlab):

--- a/terraform/modules/lambdas/functions/utilities/vcs/github_functions.py
+++ b/terraform/modules/lambdas/functions/utilities/vcs/github_functions.py
@@ -1,4 +1,4 @@
-from functools import cache
+from functools import lru_cache
 from typing import Any, Dict, List, Union
 
 from github import Auth, Github, InputGitTreeElement
@@ -10,7 +10,7 @@ from utilities.logger import logger
 from utilities.messages import HELP_MESSAGE
 
 
-@cache
+@lru_cache(maxsize=1)
 def _get_github_client(vcs_api_token: str) -> Github:
     """
     Fetches the GitHub client with a caching mechanism and verifies the session token.

--- a/terraform/modules/lambdas/functions/utilities/vcs/github_functions.py
+++ b/terraform/modules/lambdas/functions/utilities/vcs/github_functions.py
@@ -1,4 +1,4 @@
-from functools import lru_cache
+from functools import cache
 from typing import Any, Dict, List, Union
 
 from github import Auth, Github, InputGitTreeElement
@@ -10,14 +10,14 @@ from utilities.logger import logger
 from utilities.messages import HELP_MESSAGE
 
 
-@lru_cache(maxsize=1)
-def _get_github_client() -> Github:
+@cache
+def _get_github_client(vcs_api_token: str) -> Github:
     """
     Fetches the GitHub client with a caching mechanism and verifies the session token.
 
-    This function creates and caches a GitHub client for accessing the GitHub API.
-    It utilizes an `lru_cache` decorator to cache the client instance and performs
-    a lightweight health check to ensure the token and session are valid.
+    This function creates and caches a GitHub client by token for accessing the
+    GitHub API. It performs a lightweight health check to ensure the token and
+    session are valid.
 
     Returns:
         Github: An authenticated client for accessing GitHub API.
@@ -26,7 +26,7 @@ def _get_github_client() -> Github:
         Exception: If the verification of the token or session fails, the exception
             propagates to prevent caching an invalid client.
     """
-    auth = Auth.Token(config.vcs_api_token)
+    auth = Auth.Token(vcs_api_token)
     base_url = config.vcs_api_endpoint
 
     client = Github(
@@ -62,7 +62,7 @@ def get_pr_source_branch_name(repo_id_or_name: Union[int, str], pull_number: int
     """
 
     try:
-        gh = _get_github_client()
+        gh = _get_github_client(config.vcs_api_token)
         repo = gh.get_repo(repo_id_or_name)
         pr = repo.get_pull(pull_number)
         return pr.head.ref
@@ -99,7 +99,7 @@ def add_reaction_to_pr_comment_github(event: Dict[str, Any], reaction: str, ):
     """
 
     try:
-        gh = _get_github_client()
+        gh = _get_github_client(config.vcs_api_token)
         repo = gh.get_repo(event.get('metadata').get('repo_id_or_name'))
         # Ensure PR exists (will raise if not)
         pr = repo.get_pull(event.get('metadata').get('merge_or_pull_req_id'))
@@ -142,7 +142,7 @@ def post_pr_comment_github(event: Dict[str, Any], comment_text: str):
     """
 
     try:
-        gh = _get_github_client()
+        gh = _get_github_client(config.vcs_api_token)
         repo = gh.get_repo(event.get('metadata').get('repo_id_or_name'))
         # Ensure PR exists (will raise if not)
         pr = repo.get_pull(event.get('metadata').get('merge_or_pull_req_id'))
@@ -192,7 +192,7 @@ def check_files_exist_in_repo_github(event: Dict[str, Any],
         merge_or_pull_req_id = event.get('metadata').get('merge_or_pull_req_id')
         # Use the source branch of the PR as the default
         branch = get_pr_source_branch_name(repo_id_or_name, merge_or_pull_req_id)
-        gh = _get_github_client()
+        gh = _get_github_client(config.vcs_api_token)
         repo = gh.get_repo(repo_id_or_name)
         logger.debug(
             f"Checking existence of {len(file_paths)} file(s) in repo '{repo_id_or_name}' "
@@ -250,7 +250,7 @@ def commit_files_to_branch_github(event: Dict[str, Any], file_paths_with_content
         GithubException: For other GitHub API errors.
     """
     try:
-        gh = _get_github_client()
+        gh = _get_github_client(config.vcs_api_token)
         repo = gh.get_repo(event.get('metadata').get('repo_id_or_name'))
         merge_or_pull_req_id = event.get('metadata').get('merge_or_pull_req_id')
         branch = get_pr_source_branch_name(event.get('metadata').get('repo_id_or_name'), merge_or_pull_req_id)
@@ -306,7 +306,7 @@ def get_last_commit_sha_github(repo_id_or_name: Union[int, str], pull_number: in
 
     """
     try:
-        gh = _get_github_client()
+        gh = _get_github_client(config.vcs_api_token)
         repo = gh.get_repo(repo_id_or_name)
         pr = repo.get_pull(pull_number)
         return pr.head.sha
@@ -331,7 +331,7 @@ def get_all_tf_files_from_paths_list_github(
 ) -> List[tuple[str, str]]:
     repo_identifier = event.get('metadata', {}).get('repo_id_or_name')
     branch = event.get('metadata', {}).get('source_branch')
-    gh = _get_github_client()
+    gh = _get_github_client(config.vcs_api_token)
     repo = gh.get_repo(repo_identifier)
 
     tf_files: List[tuple[str, str]] = []

--- a/terraform/modules/lambdas/functions/utilities/vcs/github_functions.py
+++ b/terraform/modules/lambdas/functions/utilities/vcs/github_functions.py
@@ -10,7 +10,7 @@ from utilities.logger import logger
 from utilities.messages import HELP_MESSAGE
 
 
-@lru_cache(maxsize=1)
+@lru_cache(maxsize=2)
 def _get_github_client(vcs_api_token: str) -> Github:
     """
     Fetches the GitHub client with a caching mechanism and verifies the session token.

--- a/terraform/modules/lambdas/functions/utilities/vcs/gitlab_functions.py
+++ b/terraform/modules/lambdas/functions/utilities/vcs/gitlab_functions.py
@@ -11,7 +11,7 @@ from utilities.logger import logger
 from utilities.messages import HELP_MESSAGE
 
 
-@lru_cache(maxsize=1)
+@lru_cache(maxsize=2)
 def _get_gitlab_client(vcs_api_token: str) -> gitlab.Gitlab:
     """Return an authenticated and verified GitLab client instance."""
 

--- a/terraform/modules/lambdas/functions/utilities/vcs/gitlab_functions.py
+++ b/terraform/modules/lambdas/functions/utilities/vcs/gitlab_functions.py
@@ -1,5 +1,5 @@
 import base64
-from functools import cache
+from functools import lru_cache
 from pathlib import PurePosixPath
 from typing import Any, Dict, List
 
@@ -11,7 +11,7 @@ from utilities.logger import logger
 from utilities.messages import HELP_MESSAGE
 
 
-@cache
+@lru_cache(maxsize=1)
 def _get_gitlab_client(vcs_api_token: str) -> gitlab.Gitlab:
     """Return an authenticated and verified GitLab client instance."""
 

--- a/terraform/modules/lambdas/functions/utilities/vcs/gitlab_functions.py
+++ b/terraform/modules/lambdas/functions/utilities/vcs/gitlab_functions.py
@@ -1,5 +1,5 @@
 import base64
-from functools import lru_cache
+from functools import cache
 from pathlib import PurePosixPath
 from typing import Any, Dict, List
 
@@ -11,13 +11,13 @@ from utilities.logger import logger
 from utilities.messages import HELP_MESSAGE
 
 
-@lru_cache(maxsize=1)
-def _get_gitlab_client() -> gitlab.Gitlab:
+@cache
+def _get_gitlab_client(vcs_api_token: str) -> gitlab.Gitlab:
     """Return an authenticated and verified GitLab client instance."""
 
     client = gitlab.Gitlab(
         url=config.vcs_api_endpoint,
-        private_token=config.vcs_api_token,
+        private_token=vcs_api_token,
     )
 
     # Authenticate token
@@ -52,7 +52,7 @@ def get_mr_source_branch_name(
         GitlabGetError: If a project or MR is not found.
     """
     try:
-        gl = _get_gitlab_client()
+        gl = _get_gitlab_client(config.vcs_api_token)
         project = gl.projects.get(project_id_or_path)
         mr = project.mergerequests.get(merge_request_id)
 
@@ -93,7 +93,7 @@ def add_award_to_note_gitlab(
     """
 
     try:
-        gl = _get_gitlab_client()
+        gl = _get_gitlab_client(config.vcs_api_token)
 
         project = gl.projects.get(event.get('metadata').get('repo_id_or_name'))
         mr = project.mergerequests.get(event.get('metadata').get('merge_or_pull_req_id'))
@@ -124,7 +124,7 @@ def post_gitlab_comment(event: Dict[str, Any], comment_text: str) -> Dict[str, A
     """
 
     try:
-        gl = _get_gitlab_client()
+        gl = _get_gitlab_client(config.vcs_api_token)
         project = gl.projects.get(event.get('metadata').get('repo_id_or_name'))
         mr = project.mergerequests.get(event.get('metadata').get('merge_or_pull_req_id'))
         note = mr.notes.create({'body': comment_text})
@@ -162,7 +162,7 @@ def check_files_exist_in_repo_gitlab(
 
         branch = get_mr_source_branch_name(project_id_or_path, merge_request_id)
 
-        gl = _get_gitlab_client()
+        gl = _get_gitlab_client(config.vcs_api_token)
         project = gl.projects.get(project_id_or_path)
 
         logger.debug(
@@ -257,7 +257,7 @@ def commit_files_to_branch_gitlab(
         Exception: For unexpected errors.
     """
     try:
-        gl = _get_gitlab_client()
+        gl = _get_gitlab_client(config.vcs_api_token)
 
         metadata = event.get("metadata", {})
         project_id = metadata.get("repo_id_or_name")
@@ -322,7 +322,7 @@ def get_all_tf_files_from_paths_list_gitlab(
         event: Dict[str, Any],
         paths_list: List[str]
 ) -> List[tuple[str, str]]:
-    gl = _get_gitlab_client()
+    gl = _get_gitlab_client(config.vcs_api_token)
     project = gl.projects.get(event.get('metadata').get('repo_id_or_name'))
 
     # List to hold tuples of (repo_path, file_content_text)


### PR DESCRIPTION
## Summary

Update GitHub and GitLab client initialization so changes to VCS tokens in AWS SSM are picked up without restarting the Lambda or continuing to use a stale authenticated client.

## Changes

- Load VCS tokens, webhook secrets, and AI API tokens from SSM on every access.
- Pass the current VCS token explicitly when creating GitHub and GitLab clients.
- Cache authenticated clients by token value using an LRU cache with two entries.
- Reuse clients while the token remains unchanged and create a new client after token rotation.
- Require HTTPS for VCS and AI API endpoints.
- Correct optional configuration type annotations.
- Update mocked SSM fixtures to reflect runtime secret retrieval.
- Extend GitHub and GitLab tests to cover client reuse and token rotation.

## Motivation

Previously, both the SSM token and authenticated VCS client could remain cached after the token was updated. This caused Lambda invocations to continue using stale credentials.

Keying the client cache by the current token allows credential updates to take effect automatically while preserving client reuse for unchanged tokens.

## Testing

Tests were updated to verify:

- repeated calls with the same token reuse the cached client;
- a changed token creates a new authenticated client;
- GitHub and GitLab client authentication errors continue to propagate correctly.