### PR TITLE
feat: EPMCACMAWS-456 New pipeline state management mechanisms (#2)

### DIFF
--- a/docs/config_files/main_module/terraform.tfvars
+++ b/docs/config_files/main_module/terraform.tfvars
@@ -12,6 +12,10 @@ run_trivy_analysis     = "false" # Stage to run Trivy, a static analysis securit
 run_terraform_plan     = "false" # Stage to generate an execution plan for Terraform to show planned changes without applying them.
 run_terraform_apply    = "false" # Stage to apply the Terraform execution plan and provision infrastructure changes.
 
+# Managed workload state backend configuration (code under WORK_DIRS)
+managed_state_bucket = ""                           # (Optional) Name of an existing S3 bucket for the managed workload state. Leave empty to reuse the bootstrap platform state bucket.
+managed_state_key    = "pipeline/terraform.tfstate" # S3 key (path) for the managed workload state. Must include a directory prefix and end with .tfstate.
+
 # AI Handler block
 ai_handler_create       = "false"                                    # Flag to enable or disable AI handler creation
 rag_enable              = "false"                                    # Flag to enable or disable RAG for AI handler
@@ -19,8 +23,7 @@ artifacts_path          = "artifacts"                                # The path 
 log_level               = "INFO"                                     # The logging level for AWS Lambda functions. Possible values: DEBUG, INFO, WARN, ERROR.
 ai_api_endpoint         = "<my_ai_api_endpoint>"                     # Endpoint for AI API
 llm_model               = "<my_llm_model_name>"                      # Name of the AI model used
-oidc_provider           = "<my_oidc_provider>"                       # OIDC identity provider domain (issuer). Used for IAM condition keys and provider URL. Examples: token.actions.githubusercontent.com for GitHub, gitlab.com for GitLab
+oidc_provider           = "<my_oidc_provider>"                       # Audience for OIDC provider (gitlab.com for GitLab, token.actions.githubusercontent.com for GitHub or other for custom variant)
 artifacts_bucket_prefix = "ai-handler-artifacts-bucket"              # Prefix for the name of the artifacts S3 bucket
-tfstate_bucket_prefix   = "tfstate-bucket"                           # Prefix for the name of the tfstate S3 bucket
 private_subnet_ids      = ["<subnet_a>", "<subnet_b>", "<subnet_c>"] # List of private subnet IDs for Lambda functions
 security_groups         = ["<sg_a>"]                                 # List of security groups with inbound rules for 80 and 443 ports for Lambda functions

--- a/docs/state_management.md
+++ b/docs/state_management.md
@@ -2,38 +2,46 @@
 
 ## Overview
 
+The BrainTF project uses multiple Terraform state files stored in S3. This document covers:
+
+1. [Bootstrap state management](#bootstrap-state-management) — where the bootstrap module stores its own state.
+2. [Managed workload state management](#managed-workload-state-management) — where the CI/CD pipeline stores the Terraform state for the code under `WORK_DIRS`.
+
+---
+
+## Bootstrap State Management
+
+### What bootstrap creates
+
 The `bootstrap` module creates the AWS infrastructure required to store Terraform state remotely:
 
 - **S3 bucket** — `backend-state-bucket-{vcs_repo_name}-{region}` (stores `main_module` state)
 - **KMS key** — `alias/kms_key_{vcs_repo_name}_{region}` (encrypts state files)
 - **IAM role** — `Terraform-role-{vcs_repo_name}-{region}`
 
-After a successful `terraform apply`, bootstrap automatically injects the backend configuration into `terraform/main_module/main.tf`:
+After a successful `terraform apply`, bootstrap automatically generates `terraform/main_module/backend.generated.tf` with the backend configuration:
 
 ```hcl
 terraform {
   backend "s3" {
     bucket       = "backend-state-bucket-{vcs_repo_name}-{region}"
-    key          = "terraform.tfstate"
+    key          = "main-module/terraform.tfstate"
     region       = "{region}"
-    encrypt      = "true"
-    use_lockfile = "true"
+    encrypt      = true
+    use_lockfile = true
   }
-}
-data "aws_kms_alias" "kms_key" {
-  name = "alias/kms_key_{vcs_repo_name}_{region}"
 }
 ```
 
-## The Problem
+### The Problem
 
 By default, bootstrap's own Terraform state is stored **locally** on the machine that ran `terraform apply` (a `terraform.tfstate` file in the `terraform/bootstrap/` directory).
 
 This creates a risk: if the machine is lost or the file is deleted, you lose the ability to manage bootstrap resources (update or destroy them).
 
-## Options for Managing Bootstrap State
+### Options for Managing Bootstrap State
 
-### Option 1: Store state in the git repository
+#### Option 1: Store state in the git repository
 
 Commit `terraform.tfstate` to the repository.
 
@@ -41,11 +49,11 @@ Commit `terraform.tfstate` to the repository.
 >
 > Consider moving to Option 2 if there is a requirement to encrypt **all** Terraform state files.
 
-### Option 2: Migrate state to S3 (recommended)
+#### Option 2: Migrate state to S3 (recommended)
 
 After bootstrap creates the S3 bucket, migrate the local bootstrap state into that same bucket.
 
-#### Steps
+##### Steps
 
 1. Run bootstrap as usual:
 
@@ -87,11 +95,165 @@ After bootstrap creates the S3 bucket, migrate the local bootstrap state into th
 
 5. The local `terraform.tfstate` file in `terraform/bootstrap/` is no longer needed. It can be deleted or added to `.gitignore`.
 
-#### Result
+##### Result
 
-| Module        | State location | S3 key                     |
-|---------------|----------------|----------------------------|
-| bootstrap     | Remote S3      | `bootstrap/terraform.tfstate` |
-| main_module   | Remote S3      | `terraform.tfstate`           |
+| Module      | State location | S3 key                          |
+|-------------|----------------|---------------------------------|
+| bootstrap   | Remote S3      | `bootstrap/terraform.tfstate`   |
+| main_module | Remote S3      | `main-module/terraform.tfstate` |
 
 Both modules now store state in the same S3 bucket, protected by KMS encryption and S3 versioning.
+
+---
+
+## Managed Workload State Management
+
+### Overview
+
+The CI/CD pipeline (`terraform-plan` and `terraform-apply` stages) needs its own Terraform state file to track infrastructure deployed from the working directories (`WORK_DIRS`). This state is **separate** from the `main_module` state.
+
+The `main_module` automatically:
+1. Determines which S3 bucket to use for the managed workload state.
+2. Creates a prefix (folder) in that bucket for the managed state file.
+3. Exports the full backend configuration string as a VCS CI/CD variable (`TERRAFORM_BACKEND_PARAMS`).
+
+### Configuration Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `managed_state_bucket` | Name of the S3 bucket for the managed workload state. Leave **empty** to reuse the bootstrap platform state bucket. | `""` (empty) |
+| `managed_state_key` | The S3 object key (path) for the managed workload state file. Must include a directory prefix and end with `.tfstate`. | `pipeline/terraform.tfstate` |
+
+These are configured in `terraform/main_module/terraform.tfvars`:
+
+```hcl
+# Managed workload state backend configuration (code under WORK_DIRS)
+managed_state_bucket = ""                           # (Optional) Name of an existing S3 bucket for the managed workload state.
+managed_state_key    = "pipeline/terraform.tfstate" # S3 key (path) for the managed workload state within the chosen bucket.
+```
+
+---
+
+### Scenario A: Use the bootstrap state bucket (default)
+
+This is the simplest option — no additional buckets are needed.
+
+**When to use:** You want to keep everything in a single bucket managed by bootstrap.
+
+#### How it works
+
+1. Leave `managed_state_bucket` empty (`""`).
+2. The `main_module` automatically resolves the bootstrap state bucket name using the same formula:
+   ```
+   backend-state-bucket-{vcs_repo_name}-{region}
+   ```
+3. A prefix (folder) is created inside the bucket based on `managed_state_key`. For the default key `pipeline/terraform.tfstate`, the created prefix is `pipeline/`.
+4. The pipeline uses this backend configuration at runtime:
+   ```
+   -backend-config=bucket=backend-state-bucket-{vcs_repo_name}-{region}
+   -backend-config=key=pipeline/terraform.tfstate
+   -backend-config=region={region}
+   -backend-config=kms_key_id={kms_key_arn}
+   -backend-config=encrypt=true
+   -backend-config=use_lockfile=true
+   ```
+
+#### Resulting bucket structure
+
+```
+backend-state-bucket-{vcs_repo_name}-{region}/
+├── bootstrap/terraform.tfstate       # (if Option 2 above was used)
+├── main-module/terraform.tfstate     # main_module state
+└── pipeline/terraform.tfstate        # managed workload state (created by CI/CD)
+```
+
+#### Configuration example
+
+```hcl
+# terraform/main_module/terraform.tfvars
+managed_state_bucket = ""                           # Empty → reuse bootstrap bucket
+managed_state_key    = "pipeline/terraform.tfstate" # Folder "pipeline/" will be auto-created
+```
+
+---
+
+### Scenario B: Use a custom (user-provided) S3 bucket
+
+Use an existing S3 bucket that you manage independently (e.g., a shared bucket across multiple projects).
+
+**When to use:**
+- You want to separate the managed workload state from bootstrap infrastructure.
+- You have an existing bucket with specific policies, encryption, or cross-account access.
+
+#### Prerequisites
+
+The custom bucket must:
+- Already exist in your AWS account.
+- Have appropriate IAM permissions for the pipeline role to `s3:PutObject`, `s3:GetObject`, `s3:ListBucket`.
+- Preferably have versioning and encryption enabled.
+
+#### How it works
+
+1. Set `managed_state_bucket` to the name of your existing bucket.
+2. The `main_module` creates a prefix (folder) in the specified bucket based on `managed_state_key`. For example, key `my-project/terraform.tfstate` results in folder `my-project/`.
+3. The pipeline uses this backend configuration at runtime:
+   ```
+   -backend-config=bucket=my-custom-state-bucket
+   -backend-config=key=my-project/terraform.tfstate
+   -backend-config=region={region}
+   -backend-config=kms_key_id={kms_key_arn}
+   -backend-config=encrypt=true
+   -backend-config=use_lockfile=true
+   ```
+
+#### Resulting bucket structure
+
+```
+my-custom-state-bucket/
+└── my-project/terraform.tfstate   # managed workload state (created by CI/CD)
+```
+
+The bootstrap bucket remains untouched by managed workload state:
+
+```
+backend-state-bucket-{vcs_repo_name}-{region}/
+├── bootstrap/terraform.tfstate       # (if Option 2 above was used)
+└── main-module/terraform.tfstate     # main_module state only
+```
+
+#### Configuration example
+
+```hcl
+# terraform/main_module/terraform.tfvars
+managed_state_bucket = "my-custom-state-bucket"          # Your existing bucket
+managed_state_key    = "my-project/terraform.tfstate"    # Folder "my-project/" will be auto-created
+```
+
+---
+
+### How the prefix (folder) is created
+
+In both scenarios, the `main_module` creates an empty S3 object acting as the folder prefix. The key is derived from `managed_state_key` via `dirname()`:
+
+```hcl
+resource "aws_s3_object" "managed_state_prefix" {
+  bucket       = local.managed_state_bucket
+  key          = "${dirname(var.managed_state_key)}/"
+  content      = ""
+  content_type = "application/x-directory"
+  tags         = local.tags
+
+  lifecycle {
+    precondition {
+      condition     = dirname(var.managed_state_key) != "." && dirname(var.managed_state_key) != "/"
+      error_message = "managed_state_key must contain a directory prefix (got: '${var.managed_state_key}')."
+    }
+  }
+}
+```
+
+For `managed_state_key = "pipeline/terraform.tfstate"`, this creates the object with key `pipeline/` in the target bucket.
+
+For `managed_state_key = "envs/dev/terraform.tfstate"`, this creates the object with key `envs/dev/` in the target bucket.
+
+> **Note:** The actual state file (`terraform.tfstate`) is written by Terraform during `terraform init` in the pipeline. The `aws_s3_object` resource only ensures the parent folder exists beforehand. The `precondition` block enforces that `managed_state_key` includes a directory prefix — a bare `terraform.tfstate` (with no directory) will fail `terraform plan`.

--- a/terraform/bootstrap/README.md
+++ b/terraform/bootstrap/README.md
@@ -28,25 +28,30 @@
 | Name | Type |
 | ---- | ---- |
 | [aws_iam_role.terraform_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.terraform_state_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_s3_bucket_policy.state_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [local_file.backend_config](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_file.this](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [local_file.this](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
-| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | The account ID for the project | `string` | n/a | yes |
+| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | AWS account ID | `string` | n/a | yes |
 | <a name="input_deployed_by"></a> [deployed\_by](#input\_deployed\_by) | The deployment method | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The Project environment | `string` | n/a | yes |
 | <a name="input_owner_mail"></a> [owner\_mail](#input\_owner\_mail) | The owner e-mail | `string` | n/a | yes |
+| <a name="input_platform_state_bucket_prefix"></a> [platform\_state\_bucket\_prefix](#input\_platform\_state\_bucket\_prefix) | Custom prefix for the platform state S3 bucket name (stores state of bootstrap + main\_module) | `string` | `"backend-state-bucket"` | no |
 | <a name="input_region"></a> [region](#input\_region) | The region where AWS resources will be created | `string` | n/a | yes |
 | <a name="input_team"></a> [team](#input\_team) | The owner team | `string` | n/a | yes |
-| <a name="input_vcs_repo_name"></a> [vcs\_repo\_name](#input\_vcs\_repo\_name) | The name of the project | `string` | n/a | yes |
+| <a name="input_vcs_repo_name"></a> [vcs\_repo\_name](#input\_vcs\_repo\_name) | The Project name | `string` | n/a | yes |
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | ARN of the KMS key used for bucket encryption |
+| <a name="output_state_bucket_arn"></a> [state\_bucket\_arn](#output\_state\_bucket\_arn) | ARN of the S3 state bucket created by bootstrap |
+| <a name="output_state_bucket_name"></a> [state\_bucket\_name](#output\_state\_bucket\_name) | Name of the S3 state bucket created by bootstrap (can be reused as managed\_state\_bucket in main\_module) |
 <!-- END_TF_DOCS -->

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -1,7 +1,7 @@
 # ======================= Local Variables =======================
 locals {
-  # Define the S3 bucket name for storing the Terraform state
-  state_bucket = lower(replace(replace(replace("backend-state-bucket-${var.vcs_repo_name}-${var.region}", "_", "-"), " ", "-"), "[^a-z0-9.-]", ""))
+  # Define the S3 bucket name for storing the platform Terraform state
+  state_bucket = lower(replace(replace(replace("${var.platform_state_bucket_prefix}-${var.vcs_repo_name}-${var.region}", "_", "-"), " ", "-"), "[^a-z0-9.-]", ""))
 
   # list of .tf files in the main module to check for existing backend blocks
   main_module_tf_files = fileset("${path.module}/../main_module", "*.tf")
@@ -17,7 +17,7 @@ locals {
 terraform {
   backend "s3" {
     bucket       = "${local.state_bucket}"
-    key          = "terraform.tfstate"
+    key          = "main-module/terraform.tfstate"
     region       = "${var.region}"
     encrypt      = true
     use_lockfile = true
@@ -58,12 +58,11 @@ resource "local_file" "this" {
 }
 
 # ======================= Create a KMS Key for Encryption =======================
-data "aws_caller_identity" "current" {}
 
 module "s3_bucket_kms_key" {
   source = "git::https://github.com/terraform-aws-modules/terraform-aws-kms.git?ref=407e3db34a65b384c20ef718f55d9ceacb97a846"
 
-  description              = "KMS key for encrypting resources"
+  description              = "KMS key for encrypting Terraform state and related resources"
   enable_key_rotation      = true
   key_usage                = "ENCRYPT_DECRYPT"
   customer_master_key_spec = "SYMMETRIC_DEFAULT"
@@ -104,27 +103,6 @@ module "s3_bucket_kms_key" {
           identifiers = ["arn:aws:iam::${var.account_id}:root"]
         }
       ]
-    },
-    {
-      sid = "AllowTerraformRoleAccess"
-      actions = [
-        "kms:Encrypt",
-        "kms:Decrypt",
-        "kms:ReEncrypt*",
-        "kms:GenerateDataKey*",
-        "kms:DescribeKey",
-        "kms:ListAliases",
-        "kms:ListKeys",
-        "kms:ScheduleKeyDeletion",
-        "kms:CancelKeyDeletion"
-      ]
-      effect = "Allow"
-      principals = [
-        {
-          type        = "AWS"
-          identifiers = [data.aws_caller_identity.current.arn]
-        }
-      ]
     }
   ]
 
@@ -137,7 +115,7 @@ module "s3_state_bucket" {
   create_bucket           = true
   bucket                  = local.state_bucket
   force_destroy           = true
-  attach_policy           = false # Bucket policy will be added manually
+  attach_policy           = false
   block_public_acls       = true
   block_public_policy     = true
   ignore_public_acls      = true
@@ -153,7 +131,6 @@ module "s3_state_bucket" {
         kms_master_key_id = module.s3_bucket_kms_key.key_arn
         sse_algorithm     = "aws:kms"
       }
-
       bucket_key_enabled = true
     }
   }
@@ -169,42 +146,18 @@ resource "aws_s3_bucket_policy" "state_bucket_policy" {
     Version = "2012-10-17",
     Statement = [
       {
-        Sid    = "denyInsecureTransport",
-        Effect = "Deny",
-        Action = "s3:*",
+        Sid       = "DenyInsecureTransport",
+        Effect    = "Deny",
+        Action    = "s3:*",
+        Principal = "*",
         Resource = [
           module.s3_state_bucket.s3_bucket_arn,
           "${module.s3_state_bucket.s3_bucket_arn}/*"
         ],
-        Principal = "*",
         Condition = {
           Bool = {
             "aws:SecureTransport" = "false"
           }
-        }
-      },
-      {
-        Sid    = "AllowRootAccountAccess",
-        Effect = "Allow",
-        Action = [
-          "s3:ListBucket",
-          "s3:GetBucketLocation",
-          "s3:GetObject",
-          "s3:PutObject",
-          "s3:DeleteObject",
-          "s3:PutObjectAcl",
-          "s3:GetObjectAcl",
-          "s3:DeleteObjectVersion",
-          "s3:ListBucketVersions",
-          "s3:ListBucketMultipartUploads",
-          "s3:AbortMultipartUpload"
-        ],
-        Resource = [
-          module.s3_state_bucket.s3_bucket_arn,
-          "${module.s3_state_bucket.s3_bucket_arn}/*"
-        ],
-        Principal = {
-          AWS = "arn:aws:iam::${var.account_id}:root"
         }
       }
     ]
@@ -214,6 +167,7 @@ resource "aws_s3_bucket_policy" "state_bucket_policy" {
 # ======================= Create IAM Role =======================
 resource "aws_iam_role" "terraform_role" {
   name = "Terraform-role-${var.vcs_repo_name}-${var.region}"
+
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
     Statement = [
@@ -227,7 +181,36 @@ resource "aws_iam_role" "terraform_role" {
     ]
   })
 
-  tags = {
-    Name = "TerraformRole"
-  }
+  tags = local.tags
+}
+
+# ======================= IAM Policy for Terraform Role - State Access =======================
+resource "aws_iam_role_policy" "terraform_state_access" {
+  name = "Terraform-State-Access-${var.vcs_repo_name}-${var.region}"
+  role = aws_iam_role.terraform_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid    = "S3StateAccess",
+        Effect = "Allow",
+        Action = [
+          "s3:ListBucket",
+          "s3:GetBucketLocation",
+          "s3:GetBucketVersioning",
+          "s3:ListBucketVersions",
+          # Object-level actions
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:GetObjectVersion",
+        ],
+        Resource = [
+          module.s3_state_bucket.s3_bucket_arn,
+          "${module.s3_state_bucket.s3_bucket_arn}/*"
+        ]
+      }
+    ]
+  })
 }

--- a/terraform/bootstrap/outputs.tf
+++ b/terraform/bootstrap/outputs.tf
@@ -1,0 +1,14 @@
+output "state_bucket_name" {
+  description = "Name of the S3 state bucket created by bootstrap (can be reused as managed_state_bucket in main_module)"
+  value       = module.s3_state_bucket.s3_bucket_id
+}
+
+output "state_bucket_arn" {
+  description = "ARN of the S3 state bucket created by bootstrap"
+  value       = module.s3_state_bucket.s3_bucket_arn
+}
+
+output "kms_key_arn" {
+  description = "ARN of the KMS key used for bucket encryption"
+  value       = module.s3_bucket_kms_key.key_arn
+}

--- a/terraform/bootstrap/variables.tf
+++ b/terraform/bootstrap/variables.tf
@@ -4,12 +4,7 @@ variable "region" {
 }
 
 variable "vcs_repo_name" {
-  description = "The name of the project"
-  type        = string
-}
-
-variable "account_id" {
-  description = "The account ID for the project"
+  description = "The Project name"
   type        = string
 }
 
@@ -31,4 +26,15 @@ variable "deployed_by" {
 variable "owner_mail" {
   description = "The owner e-mail"
   type        = string
+}
+
+variable "account_id" {
+  description = "AWS account ID"
+  type        = string
+}
+
+variable "platform_state_bucket_prefix" {
+  description = "Custom prefix for the platform state S3 bucket name (stores state of bootstrap + main_module)"
+  type        = string
+  default     = "backend-state-bucket"
 }

--- a/terraform/main_module/README.md
+++ b/terraform/main_module/README.md
@@ -28,7 +28,6 @@
 | <a name="module_iam"></a> [iam](#module\_iam) | ../modules/iam | n/a |
 | <a name="module_oidc"></a> [oidc](#module\_oidc) | ../modules/oidc | n/a |
 | <a name="module_ssm_parameters"></a> [ssm\_parameters](#module\_ssm\_parameters) | git::https://github.com/terraform-aws-modules/terraform-aws-ssm-parameter.git | c0456aa1960c2b13080f3968be9a7cdc687f2c8c |
-| <a name="module_tfstate_bucket"></a> [tfstate\_bucket](#module\_tfstate\_bucket) | ../modules/bucket | n/a |
 | <a name="module_vcs_integration_github"></a> [vcs\_integration\_github](#module\_vcs\_integration\_github) | ../modules/vcs_integration/github | n/a |
 | <a name="module_vcs_integration_gitlab"></a> [vcs\_integration\_gitlab](#module\_vcs\_integration\_gitlab) | ../modules/vcs_integration/gitlab | n/a |
 
@@ -54,8 +53,11 @@
 | <a name="input_job_token"></a> [job\_token](#input\_job\_token) | Git Notes token used for GitLab integration | `string` | n/a | yes |
 | <a name="input_llm_model"></a> [llm\_model](#input\_llm\_model) | The name or identifier of the LLM (Large Language Model) to be used | `string` | n/a | yes |
 | <a name="input_log_level"></a> [log\_level](#input\_log\_level) | The logging level for AWS Lambda functions. Possible values: DEBUG, INFO, WARN, ERROR. | `string` | `"INFO"` | no |
+| <a name="input_managed_state_bucket"></a> [managed\_state\_bucket](#input\_managed\_state\_bucket) | Name of an existing S3 bucket to store Terraform state for the code under WORK\_DIRS (the workload managed by this pipeline). If empty, the bootstrap platform state bucket will be used with a separate prefix directory. | `string` | `""` | no |
+| <a name="input_managed_state_key"></a> [managed\_state\_key](#input\_managed\_state\_key) | S3 key (path) for the Terraform state file used by the managed workload (code under WORK\_DIRS). Must include a directory prefix, e.g. 'pipeline/terraform.tfstate'. | `string` | `"pipeline/terraform.tfstate"` | no |
 | <a name="input_oidc_provider"></a> [oidc\_provider](#input\_oidc\_provider) | OIDC identity provider domain (issuer). Used to construct IAM trust policy condition keys (e.g. <provider>:aud, <provider>:sub) and the OIDC provider URL. Use 'token.actions.githubusercontent.com' for GitHub or 'gitlab.com' for GitLab. | `string` | n/a | yes |
 | <a name="input_owner_mail"></a> [owner\_mail](#input\_owner\_mail) | The owner e-mail | `string` | n/a | yes |
+| <a name="input_platform_state_bucket_prefix"></a> [platform\_state\_bucket\_prefix](#input\_platform\_state\_bucket\_prefix) | Prefix for the bootstrap (platform) state S3 bucket name. Must match the value used in the bootstrap module. | `string` | `"backend-state-bucket"` | no |
 | <a name="input_private_subnet_ids"></a> [private\_subnet\_ids](#input\_private\_subnet\_ids) | VPC Private Subnet IDs | `list(string)` | n/a | yes |
 | <a name="input_rag_enable"></a> [rag\_enable](#input\_rag\_enable) | Whether to turn on RAG for AI handler. | `bool` | `false` | no |
 | <a name="input_region"></a> [region](#input\_region) | The region where AWS resources will be created | `string` | n/a | yes |
@@ -68,7 +70,6 @@
 | <a name="input_run_trivy_analysis"></a> [run\_trivy\_analysis](#input\_run\_trivy\_analysis) | Enable or disable the Trivy analysis stage. Default is false. | `bool` | `false` | no |
 | <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | Security Groups for Lambda-Git Connection | `list(string)` | n/a | yes |
 | <a name="input_team"></a> [team](#input\_team) | The owner team | `string` | n/a | yes |
-| <a name="input_tfstate_bucket_prefix"></a> [tfstate\_bucket\_prefix](#input\_tfstate\_bucket\_prefix) | The prefix to be used for naming a TFState bucket | `string` | n/a | yes |
 | <a name="input_vcs_hostname"></a> [vcs\_hostname](#input\_vcs\_hostname) | The VCS hostname for the project | `string` | n/a | yes |
 | <a name="input_vcs_project_path"></a> [vcs\_project\_path](#input\_vcs\_project\_path) | The path to the VCS project | `string` | n/a | yes |
 | <a name="input_vcs_provider"></a> [vcs\_provider](#input\_vcs\_provider) | The VCS provider used for deployment (e.g., github, gitlab) | `string` | n/a | yes |

--- a/terraform/main_module/main.tf
+++ b/terraform/main_module/main.tf
@@ -14,6 +14,7 @@ provider "gitlab" {
 data "aws_kms_alias" "kms_key" {
   name = "alias/kms_key_${var.vcs_repo_name}_${var.region}"
 }
+
 locals {
 
   tags = {
@@ -24,28 +25,33 @@ locals {
     OwnerEmail  = var.owner_mail
   }
 
+  # Compute bootstrap state bucket name (same formula as in bootstrap/main.tf)
+  bootstrap_state_bucket = lower(replace(replace(replace("${var.platform_state_bucket_prefix}-${var.vcs_repo_name}-${var.region}", "_", "-"), " ", "-"), "[^a-z0-9.-]", ""))
+
+  # Use user-provided bucket if set, otherwise fall back to the bootstrap state bucket
+  managed_state_bucket = var.managed_state_bucket != "" ? var.managed_state_bucket : local.bootstrap_state_bucket
+
   # Conditional variables
   oidc_role_name         = "${var.vcs_repo_name}-oidc-${var.vcs_provider}-${var.region}-role"
   oidc_policy_name       = "${var.vcs_repo_name}-oidc-${var.vcs_provider}-${var.region}-policy"
   artifacts_bucket       = lower(replace(replace(replace("${var.artifacts_bucket_prefix}-${var.vcs_repo_name}-${var.region}", "_", "-"), " ", "-"), "[^a-z0-9.-]", ""))
-  tfstate_bucket         = lower(replace(replace(replace("${var.tfstate_bucket_prefix}-${var.vcs_repo_name}-${var.region}", "_", "-"), " ", "-"), "[^a-z0-9.-]", ""))
   ai_dynamodb_table_name = "ai-chat-history-${var.vcs_repo_name}-${var.region}"
   webhook_secret_name    = "/${var.vcs_repo_name}/webhook_secret"
   ai_api_token_name      = "/${var.vcs_repo_name}/ai_token"
   vcs_token_name         = "/${var.vcs_repo_name}/vcs_token"
-  vcs_api_endpoint       = (var.vcs_provider == "github" ? "https://api.${var.vcs_hostname}" : "https://${var.vcs_hostname}")                                   # VCS API endpoint
-  aud_variable           = "${var.oidc_provider}:aud"                                                                                                           # Logic for 'aud' variable based on VCS provider
-  sub_variable           = "${var.oidc_provider}:sub"                                                                                                           # Logic for 'sub' variable based on VCS provider
-  sub_values             = (var.vcs_provider == "github" ? ["repo:${var.vcs_project_path}:*"] : ["project_path:${var.vcs_project_path}:ref_type:branch:ref:*"]) # Values for 'sub' condition based on VCS provider
-  client_id_list         = (var.vcs_provider == "github" ? ["sts.amazonaws.com"] : ["https://${var.oidc_provider}"])                                            # Values for 'client id list' condition based on VCS provider
+  vcs_api_endpoint       = (var.vcs_provider == "github" ? "https://api.${var.vcs_hostname}" : "https://${var.vcs_hostname}")
+  aud_variable           = "${var.oidc_provider}:aud"
+  sub_variable           = "${var.oidc_provider}:sub"
+  sub_values             = (var.vcs_provider == "github" ? ["repo:${var.vcs_project_path}:*"] : ["project_path:${var.vcs_project_path}:ref_type:branch:ref:*"])
+  client_id_list         = (var.vcs_provider == "github" ? ["sts.amazonaws.com"] : ["https://${var.oidc_provider}"])
   terraform_backend_params = join(" ", [
-    "-backend-config=bucket=${local.tfstate_bucket}",
-    "-backend-config=key=terraform.tfstate",
+    "-backend-config=bucket=${local.managed_state_bucket}",
+    "-backend-config=key=${var.managed_state_key}",
     "-backend-config=region=${var.region}",
     "-backend-config=kms_key_id=${data.aws_kms_alias.kms_key.arn}",
     "-backend-config=encrypt=true",
     "-backend-config=use_lockfile=true"
-  ]) # Backend parameters string for Terraform pipeline
+  ])
 
   # VCS variables for GitHub or GitLab
   git_owner = regex("^([^/]+)", var.vcs_project_path)[0]
@@ -88,13 +94,6 @@ locals {
       },
     ] : [],
     [
-      {
-        key         = "TFSTATE_BUCKET"
-        value       = "${local.tfstate_bucket}/logs"
-        description = "The S3 bucket for Terraform states (Managed by Terraform)"
-        masked      = false
-        protected   = false
-      },
       {
         key         = "VCS_API_ENDPOINT"
         value       = var.vcs_provider == "gitlab" ? "${local.vcs_api_endpoint}/api/v4" : local.vcs_api_endpoint
@@ -238,32 +237,6 @@ module "artifacts_bucket" {
   directories        = ["logs/", "artifacts/"]
 }
 
-# ======================= TFState Bucket =======================
-module "tfstate_bucket" {
-  source        = "../modules/bucket"
-  count         = var.ai_handler_create ? 1 : 0
-  bucket_name   = local.tfstate_bucket
-  kms_key_arn   = data.aws_kms_alias.kms_key.target_key_arn
-  force_destroy = true
-  lifecycle_rules = [
-    {
-      id                                     = "tfstate"
-      enabled                                = true
-      prefix                                 = "tfstate/*"
-      expiration_date                        = null # Date for expiration (RFC3339 format)
-      expiration_days                        = 3    # Days for expiration
-      expired_object_delete_marker           = null # Flag for delete marker expiration
-      noncurrent_version_expiration_days     = 1    # Days for noncurrent version expiration
-      abort_incomplete_multipart_upload_days = 7    # Days to abort incomplete multipart uploads
-    }
-  ]
-  account_id         = var.account_id
-  tags               = local.tags
-  create_directories = true # Create directories
-  directories        = ["tfstate/"]
-}
-
-
 # ======================= SSM Parameters =======================
 module "ssm_parameters" {
   source           = "git::https://github.com/terraform-aws-modules/terraform-aws-ssm-parameter.git?ref=c0456aa1960c2b13080f3968be9a7cdc687f2c8c"
@@ -278,19 +251,20 @@ module "ssm_parameters" {
 
 # ======================= OIDC Provider =======================
 module "oidc" {
-  source           = "../modules/oidc"
-  count            = var.ai_handler_create ? 1 : 0
-  vcs_provider     = var.vcs_provider
-  oidc_role_name   = local.oidc_role_name
-  oidc_policy_name = local.oidc_policy_name
-  oidc_provider    = var.oidc_provider
-  artifacts_bucket = local.artifacts_bucket
-  kms_key_arn      = data.aws_kms_alias.kms_key.target_key_arn
-  client_id_list   = local.client_id_list
-  aud_variable     = local.aud_variable
-  sub_values       = local.sub_values
-  sub_variable     = local.sub_variable
-  tags             = local.tags
+  source               = "../modules/oidc"
+  count                = var.ai_handler_create ? 1 : 0
+  vcs_provider         = var.vcs_provider
+  oidc_role_name       = local.oidc_role_name
+  oidc_policy_name     = local.oidc_policy_name
+  oidc_provider        = var.oidc_provider
+  artifacts_bucket     = local.artifacts_bucket
+  managed_state_bucket = local.managed_state_bucket
+  kms_key_arn          = data.aws_kms_alias.kms_key.target_key_arn
+  client_id_list       = local.client_id_list
+  aud_variable         = local.aud_variable
+  sub_values           = local.sub_values
+  sub_variable         = local.sub_variable
+  tags                 = local.tags
 }
 
 # ======================= IAM Roles and Policies for Lambda =======================
@@ -308,8 +282,8 @@ module "iam" {
 
 # ======================= DynamoDB tables =======================
 module "ai_dynamodb_table" {
-  source = "../modules/dynamodb"
-  # count       = var.ai_handler_create ? 1 : 0
+  source    = "../modules/dynamodb"
+  count     = var.ai_handler_create ? 1 : 0
   name      = local.ai_dynamodb_table_name
   hash_key  = "pk"
   range_key = "sk"

--- a/terraform/main_module/variables.tf
+++ b/terraform/main_module/variables.tf
@@ -65,13 +65,13 @@ variable "vcs_project_path" {
 variable "artifacts_path" {
   description = "The path where the corrected Terraform files (artifacts) will be stored."
   type        = string
-  default     = "artifacts" # Default path for storing Terraform artifacts
+  default     = "artifacts"
 }
 
 variable "log_level" {
   description = "The logging level for AWS Lambda functions. Possible values: DEBUG, INFO, WARN, ERROR."
   type        = string
-  default     = "INFO" # Default log level for Lambda functions
+  default     = "INFO"
 
   validation {
     condition     = contains(["DEBUG", "INFO", "WARN", "ERROR"], var.log_level)
@@ -96,9 +96,27 @@ variable "artifacts_bucket_prefix" {
   type        = string
 }
 
-variable "tfstate_bucket_prefix" {
-  description = "The prefix to be used for naming a TFState bucket"
+variable "platform_state_bucket_prefix" {
+  description = "Prefix for the bootstrap (platform) state S3 bucket name. Must match the value used in the bootstrap module."
   type        = string
+  default     = "backend-state-bucket"
+}
+
+variable "managed_state_bucket" {
+  description = "Name of an existing S3 bucket to store Terraform state for the code under WORK_DIRS (the workload managed by this pipeline). If empty, the bootstrap platform state bucket will be used with a separate prefix directory."
+  type        = string
+  default     = ""
+}
+
+variable "managed_state_key" {
+  description = "S3 key (path) for the Terraform state file used by the managed workload (code under WORK_DIRS). Must include a directory prefix, e.g. 'pipeline/terraform.tfstate'."
+  type        = string
+  default     = "pipeline/terraform.tfstate"
+
+  validation {
+    condition     = can(regex("^[^/].*/.+\\.tfstate$", var.managed_state_key))
+    error_message = "managed_state_key must include a directory prefix and end with .tfstate (e.g. 'pipeline/terraform.tfstate'). Leading slash is not allowed."
+  }
 }
 
 variable "llm_model" {
@@ -110,7 +128,6 @@ variable "ai_api_endpoint" {
   description = "The API endpoint for the AI service"
   type        = string
 }
-
 
 variable "private_subnet_ids" {
   description = "VPC Private Subnet IDs"

--- a/terraform/modules/oidc/README.md
+++ b/terraform/modules/oidc/README.md
@@ -40,6 +40,7 @@ No modules.
 | <a name="input_aud_variable"></a> [aud\_variable](#input\_aud\_variable) | The audience variable for the OIDC provider | `string` | n/a | yes |
 | <a name="input_client_id_list"></a> [client\_id\_list](#input\_client\_id\_list) | List of client IDs for the OIDC provider | `list(string)` | n/a | yes |
 | <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The ARN of the KMS key for encryption | `string` | n/a | yes |
+| <a name="input_managed_state_bucket"></a> [managed\_state\_bucket](#input\_managed\_state\_bucket) | The name of the S3 bucket used for the managed workload Terraform state | `string` | n/a | yes |
 | <a name="input_oidc_policy_name"></a> [oidc\_policy\_name](#input\_oidc\_policy\_name) | The name of the IAM policy to create | `string` | n/a | yes |
 | <a name="input_oidc_provider"></a> [oidc\_provider](#input\_oidc\_provider) | The oidc provider | `string` | n/a | yes |
 | <a name="input_oidc_role_name"></a> [oidc\_role\_name](#input\_oidc\_role\_name) | The name of the IAM role to create | `string` | n/a | yes |

--- a/terraform/modules/oidc/main.tf
+++ b/terraform/modules/oidc/main.tf
@@ -14,7 +14,7 @@ resource "aws_iam_openid_connect_provider" "vcs_oidc_provider" {
 # IAM AssumeRole policy for OIDC
 data "aws_iam_policy_document" "vcs_assume_role_policy" {
   statement {
-    actions = ["sts:AssumeRoleWithWebIdentity"] # Allow VCS to assume the role
+    actions = ["sts:AssumeRoleWithWebIdentity"]
     principals {
       type        = "Federated"
       identifiers = [aws_iam_openid_connect_provider.vcs_oidc_provider.arn]
@@ -45,23 +45,43 @@ resource "aws_iam_role" "vcs_oidc_role" {
 
 # Define IAM policy for OIDC integration
 data "aws_iam_policy_document" "oidc_policy" {
+
   statement {
+    sid    = "ArtifactsBucketAccess"
     effect = "Allow"
     actions = [
-      "s3:PutObject", # Allow uploading objects to S3
-      "s3:GetObject", # Allow downloading objects from S3
-      "s3:ListBucket" # Allow listing bucket contents
+      "s3:ListBucket",
+      "s3:GetObject",
+      "s3:PutObject"
     ]
     resources = [
-      "arn:aws:s3:::${var.artifacts_bucket}",  # Restrict access to the specified bucket
-      "arn:aws:s3:::${var.artifacts_bucket}/*" # Restrict access to objects in the bucket
+      "arn:aws:s3:::${var.artifacts_bucket}",
+      "arn:aws:s3:::${var.artifacts_bucket}/*"
+    ]
+  }
+
+  statement {
+    sid    = "ManagedStateBucketAccess"
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket",
+      "s3:GetBucketVersioning",
+      "s3:GetBucketLocation",
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+      "s3:GetObjectVersion"
+    ]
+    resources = [
+      "arn:aws:s3:::${var.managed_state_bucket}",
+      "arn:aws:s3:::${var.managed_state_bucket}/*"
     ]
   }
 
   statement {
     effect = "Allow"
     actions = [
-      "sts:AssumeRoleWithWebIdentity" # Allow assuming the role via OIDC
+      "sts:AssumeRoleWithWebIdentity"
     ]
     resources = [aws_iam_role.vcs_oidc_role.arn]
   }

--- a/terraform/modules/oidc/variables.tf
+++ b/terraform/modules/oidc/variables.tf
@@ -23,6 +23,11 @@ variable "artifacts_bucket" {
   type        = string
 }
 
+variable "managed_state_bucket" {
+  description = "The name of the S3 bucket used for the managed workload Terraform state"
+  type        = string
+}
+
 variable "kms_key_arn" {
   description = "The ARN of the KMS key for encryption"
   type        = string


### PR DESCRIPTION
# Why we need this PR

Unify Terraform state management across `bootstrap`, `main_module`, and CI/CD:

- Drop the dedicated `tfstate_bucket` for the pipeline state; reuse the bootstrap bucket by default (or a user-provided one).
- Introduce a clear state layout with per-module prefixes: `bootstrap/`, `main-module/`, `pipeline/`.
- Tighten IAM/KMS access to the state backend with explicit least-privilege permissions for the Terraform role.

# What was done

**Bootstrap (`terraform/bootstrap`)**
- New `platform_state_bucket_prefix` variable (default `backend-state-bucket`) → final name `<prefix>-<vcs_repo_name>-<region>`.
- `main_module` state moved to `main-module/terraform.tfstate`; prefix pre-created via `aws_s3_object.main_module_state_prefix`.
- Backend config for `main_module` is now written to a separate `backend.generated.tf` (skipped if a backend block already exists elsewhere).
- Bucket policy simplified: kept only `DenyInsecureTransport` (renamed from `denyInsecureTransport`); removed `AllowRootAccountAccess`.
- Added IAM role policy `Terraform-State-Access-*` on `Terraform-role-*` with `S3StateAccess` (bucket + object) and `KMSStateAccess` (`Decrypt`/`GenerateDataKey`/`DescribeKey`).
- KMS key policy left with root-only access; the previous `AllowTerraformRoleAccess` KMS statement and `aws_caller_identity` data source removed — KMS access for the role is now via the IAM policy above.
- New outputs: `state_bucket_name`, `state_bucket_arn`, `kms_key_arn`.

**Main module (`terraform/main_module`)**
- Removed `tfstate_bucket` module and `tfstate_bucket_prefix` variable.
- New variables:
    - `platform_state_bucket_prefix` — must match `bootstrap`.
    - `managed_state_bucket` — optional custom bucket; empty ⇒ fall back to bootstrap bucket.
    - `managed_state_key` — default `pipeline/terraform.tfstate`; regex-validated (directory prefix required, `.tfstate` suffix, no leading slash).
- `local.bootstrap_state_bucket` recomputes the bootstrap bucket name with the same normalization; `local.managed_state_bucket` resolves user-provided or fallback.
- `aws_s3_object.managed_state_prefix` pre-creates the folder (`${dirname(var.managed_state_key)}/`, `content_type = "application/x-directory"`, `lifecycle.precondition` guards against missing prefix).
- `TERRAFORM_BACKEND_PARAMS` now points to the resolved bucket + key.
- Removed the `TFSTATE_BUCKET` CI/CD variable.
- `ai_dynamodb_table` made conditional: `count = var.ai_handler_create ? 1 : 0`.

**OIDC module (`terraform/modules/oidc`)**
- New required input `managed_state_bucket`.
- Split OIDC policy into `ArtifactsBucketAccess` and `ManagedStateBucketAccess` statements; KMS access for the OIDC role retained.

**Config files (`docs/config_files`)**
- `bootstrap/terraform.tfvars`: added `platform_state_bucket_prefix`; clarified `deployed_by` placeholder.
- `main_module/terraform.tfvars`: removed `tfstate_bucket_prefix`; added `managed_state_bucket` / `managed_state_key`; fixed `oidc_provider` comment.

**Documentation**
- `docs/state_management.md` restructured into *Bootstrap* and *Managed Workload* sections, with both scenarios (reuse bootstrap bucket / custom bucket), bucket-structure diagrams, and the prefix pre-creation snippet.
- `README.md` files regenerated via `terraform-docs` for `bootstrap`, `main_module`, and `modules/oidc`.

# Known issues

None.

# How this was tested

- `terraform validate` / `terraform plan` on `bootstrap` and `main_module`.
- End-to-end: bootstrap creates the bucket with expected prefixes; `main_module` writes state under `main-module/`; pipeline writes state under `managed_state_key` in both Scenario A (bootstrap bucket) and Scenario B (custom bucket).
- Manual review of the generated `backend.generated.tf` and `TERRAFORM_BACKEND_PARAMS`.
- Verified that `managed_state_key` validation and the `precondition` reject a bare `terraform.tfstate` with a clear error.