### PR TITLE
feat: EPMCACMAWS-487 Return a Descriptive Message When Requested Files Are Unavailable for Approval

### DIFF
--- a/terraform/modules/lambdas/functions/config.py
+++ b/terraform/modules/lambdas/functions/config.py
@@ -46,7 +46,7 @@ class _ConfigLambda:
         DYNAMODB_TABLE_NAME: Sets the application’s DynamoDB table name.
         LOG_LEVEL: Controls the log verbosity.
         RAG_ENABLED: Toggles Retrieval-Augmented Generation support.
-        TTL_DELTA_DAYS: Adjusts the TTL offset in days.
+        TTL_DELTA_DAYS: Adjusts the TTL offset, days.
 
     Notes:
         * URLs must use the ``https`` scheme to pass validation.
@@ -54,7 +54,7 @@ class _ConfigLambda:
         * VCS tokens, webhook secrets, and AI API tokens are loaded from SSM on
           each access.
           Other expensive AWS lookups may still be memoized where appropriate.
-        * Validation raises ``ValueError`` with descriptive messages whenever required
+        * Validation raises ``ValueError`` with descriptive messages whenever the required
           configuration is missing or malformed.
     """
 
@@ -68,7 +68,7 @@ class _ConfigLambda:
         self.vcs_token_name: str | None = os.environ.get('VCS_TOKEN_NAME')
         self.vcs_api_endpoint: str | None = os.environ.get('VCS_API_ENDPOINT')
         self.webhook_secret_name: str | None = os.environ.get('WEBHOOK_SECRET_NAME')
-        self.artifacts_bucket: str | None = os.environ.get('ARTIFACTS_BUCKET')
+        self.artifacts_bucket: str = os.environ.get('ARTIFACTS_BUCKET', '')
         self.path_to_artifacts: str = os.environ.get('ARTIFACTS_PATH', 'artifacts')
         self.ai_api_token_name: str | None = os.environ.get('AI_API_TOKEN_NAME')
         self.llm_model: str | None = os.environ.get("LLM_MODEL")
@@ -172,8 +172,8 @@ class _ConfigLambda:
             str: The decrypted VCS API token.
 
         Raises:
-            botocore.exceptions.ClientError: If there are issues retrieving the
-                parameter from AWS SSM, such as access restrictions or if the
+            botocore.exceptions.ClientError: If there are issues when retrieving the
+                parameter from AWS SSM, such as access restrictions, or if the
                 parameter does not exist.
         """
         ssm = boto3.client('ssm', config=self.boto3_config)

--- a/terraform/modules/lambdas/functions/tests/utilities/handlers/test_handlers.py
+++ b/terraform/modules/lambdas/functions/tests/utilities/handlers/test_handlers.py
@@ -310,8 +310,8 @@ def test_handle_approve_command_specific_reports_single_unavailable_file(
     assert comments == [
         ':information_source: AI Bot message\n\n'
         '---\n'
-        '> :no_entry: Not available  \n'
-        '> The following files are not available for approval: **demo/broken/missing.tf**.  \n'
+        '> :no_entry: Not available\\\n'
+        '> The following files are not available for approval: **demo/broken/missing.tf**.\\\n'
         '> Comment `bot list` to see corrected files currently available for approval.'
     ]
     assert commit_calls == []
@@ -348,9 +348,9 @@ def test_handle_approve_command_specific_reports_all_unavailable_files(
     assert comments == [
         ':information_source: AI Bot message\n\n'
         '---\n'
-        '> :no_entry: Not available  \n'
+        '> :no_entry: Not available\\\n'
         '> The following files are not available for approval: '
-        '**demo/broken/first.tf, demo/broken/second.tf**.  \n'
+        '**demo/broken/first.tf, demo/broken/second.tf**.\\\n'
         '> Comment `bot list` to see corrected files currently available for approval.'
     ]
     assert commit_calls == []

--- a/terraform/modules/lambdas/functions/tests/utilities/handlers/test_handlers.py
+++ b/terraform/modules/lambdas/functions/tests/utilities/handlers/test_handlers.py
@@ -280,6 +280,71 @@ def test_handle_approve_command_specific_checks_repo_before_commit(patched_envir
     assert comments == ['Some selected files do not exist in the repository.']
 
 
+def test_handle_approve_command_specific_reports_single_unavailable_file(
+        patched_environment, webhook_event_command_bot_approve_all_context_github, monkeypatch):
+    from utilities import handlers
+
+    comments = []
+    commit_calls = []
+
+    monkeypatch.setattr(
+        "utilities.handlers.get_file_names_from_s3_directory",
+        lambda bucket_name, path_to_files: ['demo/broken/main.tf']
+    )
+    monkeypatch.setattr("utilities.handlers.post_comment", lambda event, body: comments.append(body))
+    monkeypatch.setattr(
+        "utilities.handlers.commit_files_to_branch",
+        lambda event, files, commit_message: commit_calls.append((files, commit_message))
+    )
+
+    handlers.handle_approve_command(
+        webhook_event_command_bot_approve_all_context_github,
+        ['demo/broken/missing.tf']
+    )
+
+    assert comments == [
+        ':information_source: AI Bot message\n\n'
+        '---\n'
+        '> :no_entry: Not available\n'
+        '> The following files are not available for approval: **demo/broken/missing.tf**.\n'
+        '> Comment `bot list` to see corrected files currently available for approval.'
+    ]
+    assert commit_calls == []
+
+
+def test_handle_approve_command_specific_reports_all_unavailable_files(
+        patched_environment, webhook_event_command_bot_approve_all_context_github, monkeypatch):
+    from utilities import handlers
+
+    comments = []
+    commit_calls = []
+
+    monkeypatch.setattr(
+        "utilities.handlers.get_file_names_from_s3_directory",
+        lambda bucket_name, path_to_files: ['demo/broken/main.tf']
+    )
+    monkeypatch.setattr("utilities.handlers.post_comment", lambda event, body: comments.append(body))
+    monkeypatch.setattr(
+        "utilities.handlers.commit_files_to_branch",
+        lambda event, files, commit_message: commit_calls.append((files, commit_message))
+    )
+
+    handlers.handle_approve_command(
+        webhook_event_command_bot_approve_all_context_github,
+        ['demo/broken/main.tf', 'demo/broken/first.tf', 'demo/broken/second.tf']
+    )
+
+    assert comments == [
+        ':information_source: AI Bot message\n\n'
+        '---\n'
+        '> :no_entry: Not available\n'
+        '> The following files are not available for approval: '
+        '**demo/broken/first.tf, demo/broken/second.tf**.\n'
+        '> Comment `bot list` to see corrected files currently available for approval.'
+    ]
+    assert commit_calls == []
+
+
 def test_handle_approve_command_specific_deletes_artifacts_after_commit(patched_environment,
                                                                        webhook_event_command_bot_approve_all_context_github,
                                                                        monkeypatch):

--- a/terraform/modules/lambdas/functions/tests/utilities/handlers/test_handlers.py
+++ b/terraform/modules/lambdas/functions/tests/utilities/handlers/test_handlers.py
@@ -286,7 +286,12 @@ def test_handle_approve_command_specific_reports_single_unavailable_file(
 
     comments = []
     commit_calls = []
+    award_calls = []
 
+    monkeypatch.setattr(
+        "utilities.handlers.add_award_to_note",
+        lambda event, award: award_calls.append((event, award))
+    )
     monkeypatch.setattr(
         "utilities.handlers.get_file_names_from_s3_directory",
         lambda bucket_name, path_to_files: ['demo/broken/main.tf']
@@ -305,11 +310,12 @@ def test_handle_approve_command_specific_reports_single_unavailable_file(
     assert comments == [
         ':information_source: AI Bot message\n\n'
         '---\n'
-        '> :no_entry: Not available\n'
-        '> The following files are not available for approval: **demo/broken/missing.tf**.\n'
+        '> :no_entry: Not available  \n'
+        '> The following files are not available for approval: **demo/broken/missing.tf**.  \n'
         '> Comment `bot list` to see corrected files currently available for approval.'
     ]
     assert commit_calls == []
+    assert award_calls == [(webhook_event_command_bot_approve_all_context_github, handlers.FAILURE)]
 
 
 def test_handle_approve_command_specific_reports_all_unavailable_files(
@@ -318,7 +324,12 @@ def test_handle_approve_command_specific_reports_all_unavailable_files(
 
     comments = []
     commit_calls = []
+    award_calls = []
 
+    monkeypatch.setattr(
+        "utilities.handlers.add_award_to_note",
+        lambda event, award: award_calls.append((event, award))
+    )
     monkeypatch.setattr(
         "utilities.handlers.get_file_names_from_s3_directory",
         lambda bucket_name, path_to_files: ['demo/broken/main.tf']
@@ -337,12 +348,13 @@ def test_handle_approve_command_specific_reports_all_unavailable_files(
     assert comments == [
         ':information_source: AI Bot message\n\n'
         '---\n'
-        '> :no_entry: Not available\n'
+        '> :no_entry: Not available  \n'
         '> The following files are not available for approval: '
-        '**demo/broken/first.tf, demo/broken/second.tf**.\n'
+        '**demo/broken/first.tf, demo/broken/second.tf**.  \n'
         '> Comment `bot list` to see corrected files currently available for approval.'
     ]
     assert commit_calls == []
+    assert award_calls == [(webhook_event_command_bot_approve_all_context_github, handlers.FAILURE)]
 
 
 def test_handle_approve_command_specific_deletes_artifacts_after_commit(patched_environment,

--- a/terraform/modules/lambdas/functions/utilities/handlers.py
+++ b/terraform/modules/lambdas/functions/utilities/handlers.py
@@ -259,6 +259,7 @@ def handle_approve_command(event: Dict[str, Any], rest_comment: List[str]) -> No
         if wrong_files:
             logger.warning(f'Requested files are not available for approval: {wrong_files}.')
             unavailable_files = ', '.join(wrong_files)
+            add_award_to_note(event, FAILURE)
             post_comment(
                 event,
                 UNAVAILABLE_APPROVAL_FILES_MESSAGE.format(unavailable_files=unavailable_files)

--- a/terraform/modules/lambdas/functions/utilities/handlers.py
+++ b/terraform/modules/lambdas/functions/utilities/handlers.py
@@ -12,7 +12,8 @@ from utilities.aws import (delete_files_from_s3,
                            upload_files_to_s3)
 from utilities.exceptions import InvalidEventMetadata
 from utilities.logger import logger
-from utilities.messages import AI_RESPONSE_MESSAGE, LIST_FILES_MESSAGE
+from utilities.messages import (AI_RESPONSE_MESSAGE, LIST_FILES_MESSAGE,
+                                UNAVAILABLE_APPROVAL_FILES_MESSAGE)
 from utilities.parsers import parse_hcl_blocks
 from utilities.vcs import (FAILURE, SUCCESS, add_award_to_note,
                            check_files_exist_in_repo, commit_files_to_branch,
@@ -255,11 +256,13 @@ def handle_approve_command(event: Dict[str, Any], rest_comment: List[str]) -> No
         fixed_files: list[str] = get_file_names_from_s3_directory(config.artifacts_bucket, path_to_files_for_approval)
 
         wrong_files = [file_name for file_name in rest_comment if file_name not in fixed_files]
-        #
         if wrong_files:
             logger.warning(f'Requested files are not available for approval: {wrong_files}.')
-            # add_award_to_note(event, 'rotating_light')
-            post_comment(event, f'Invalid rest_comment: {wrong_files}')
+            unavailable_files = ', '.join(wrong_files)
+            post_comment(
+                event,
+                UNAVAILABLE_APPROVAL_FILES_MESSAGE.format(unavailable_files=unavailable_files)
+            )
         else:
             add_award_to_note(event, SUCCESS)
 

--- a/terraform/modules/lambdas/functions/utilities/messages.py
+++ b/terraform/modules/lambdas/functions/utilities/messages.py
@@ -49,8 +49,8 @@ UNAVAILABLE_APPROVAL_FILES_MESSAGE: str = """
 :information_source: AI Bot message
 
 ---
-> :no_entry: Not available
-> The following files are not available for approval: **{unavailable_files}**.
+> :no_entry: Not available  
+> The following files are not available for approval: **{unavailable_files}**.  
 > Comment `bot list` to see corrected files currently available for approval.
 """.lstrip().removesuffix("\n")
 

--- a/terraform/modules/lambdas/functions/utilities/messages.py
+++ b/terraform/modules/lambdas/functions/utilities/messages.py
@@ -45,6 +45,15 @@ List of files corrected by AI bot
 
 """
 
+UNAVAILABLE_APPROVAL_FILES_MESSAGE: str = """
+:information_source: AI Bot message
+
+---
+> :no_entry: Not available
+> The following files are not available for approval: **{unavailable_files}**.
+> Comment `bot list` to see corrected files currently available for approval.
+""".lstrip().removesuffix("\n")
+
 AI_RESPONSE_MESSAGE: str = """
 :information_source: AI Bot message
 

--- a/terraform/modules/lambdas/functions/utilities/messages.py
+++ b/terraform/modules/lambdas/functions/utilities/messages.py
@@ -49,8 +49,8 @@ UNAVAILABLE_APPROVAL_FILES_MESSAGE: str = """
 :information_source: AI Bot message
 
 ---
-> :no_entry: Not available  
-> The following files are not available for approval: **{unavailable_files}**.  
+> :no_entry: Not available\\
+> The following files are not available for approval: **{unavailable_files}**.\\
 > Comment `bot list` to see corrected files currently available for approval.
 """.lstrip().removesuffix("\n")
 


### PR DESCRIPTION
## Summary

Improve specific-file approval handling when one or more requested files are not available among the generated artifacts.

## Changes

- Add a descriptive message listing unavailable approval files.
- Direct users to `bot list` to see files currently available for approval.
- Add a failure award to the originating note when validation fails.
- Prevent the commit operation when any requested file is unavailable.
- Add tests covering single and multiple unavailable files.
- Default `ARTIFACTS_BUCKET` to an empty string when it is not configured.
- Clean up related configuration documentation.

## Testing

- Added unit coverage for single and multiple unavailable-file scenarios.