### PR TITLE
feat:EPMCACMAWS-490:Replace null_resource with docker Terraform provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ env/
 # Python-related files
 pip-log.txt
 layer.zip
+**/functions/python/
 pip-delete-this-directory.txt
 .coverage
 .tox/

--- a/terraform/modules/lambdas/README.md
+++ b/terraform/modules/lambdas/README.md
@@ -7,6 +7,7 @@
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7, < 2.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_docker"></a> [docker](#requirement\_docker) | ~> 3.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >=3.0 |
 
 ## Providers
@@ -14,6 +15,7 @@
 | Name | Version |
 | ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_docker"></a> [docker](#provider\_docker) | ~> 3.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | >=3.0 |
 
 ## Modules
@@ -31,6 +33,7 @@
 | [aws_lambda_layer_version.layer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_layer_version) | resource |
 | [aws_lambda_permission.allow_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_s3_bucket_notification.bucket_notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
+| [docker_container.lambda_layer](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs/resources/container) | resource |
 | [null_resource.lambda_layer](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 
 ## Inputs

--- a/terraform/modules/lambdas/main.tf
+++ b/terraform/modules/lambdas/main.tf
@@ -1,9 +1,8 @@
 #======================= The Lambda function for AI Handler =======================#
 locals {
   # Path to the functions directory
-  layer_path      = "${path.root}/functions"
+  layer_path      = "${path.module}/functions"
   zip_file_path   = "${path.module}/functions/layer.zip" # Path to the output ZIP file
-  zip_file_exists = fileexists(local.zip_file_path)      # Check if the ZIP file exists
   # Patterns to exclude from Lambda deployment package
   lambda_exclude_patterns = [
     "!.*\\.pyc$",
@@ -14,41 +13,39 @@ locals {
   ]
 }
 
+# Install Python dependencies (replaces `docker run` in null_resource)
+resource "docker_container" "lambda_layer" {
+  count    = var.ai_handler_create == "true" ? 1 : 0
+  name     = "braintf-${var.vcs_repo_name}-lambda-layer"
+  image    = "public.ecr.aws/sam/build-python3.11:latest"
+  attach   = true
+  must_run = false
+  command = [
+    "/bin/sh",
+    "-c",
+    "pip install --no-cache-dir -q -r requirements.txt -t python/lib/python3.11/site-packages/ && zip -m -q -r layer.zip python"
+  ]
+
+  volumes {
+    host_path      = abspath(local.layer_path)
+    container_path = "/var/task"
+  }
+}
+
 # Create a zip file from requirements.txt. Triggers only when the file is updated or ZIP file is missing
 resource "null_resource" "lambda_layer" {
-  count = var.ai_handler_create == "true" ? 1 : 0
+  count      = var.ai_handler_create == "true" ? 1 : 0
+  depends_on = [docker_container.lambda_layer]
   triggers = {
     # Trigger when requirements.txt changes
     requirements = filesha1("${path.module}/functions/requirements.txt")
-    # Trigger when the ZIP file is missing or needs to be recreated
-    zip_missing = local.zip_file_exists ? filesha256(local.zip_file_path) : "true"
   }
-  # The command to install Python dependencies and prepare the build directory
   provisioner "local-exec" {
     command = <<EOT
-    echo "Starting Docker command..."
-
-    # Navigate to the module directory
-    cd ${path.module}
-
-    # Remove previous Python directory and ZIP file if they exist
-    echo "Cleaning up previous Python directory and ZIP file..."
-    rm -rf functions/python || true
-    rm -f functions/layer.zip || true
-
-    # Install required Python libraries into the build directory
-    echo "Installing dependencies..."
-    docker run --platform linux/amd64 --user $(id -u):$(id -g) --rm \
-      -v ${local.layer_path}:/var/task "public.ecr.aws/sam/build-python3.11" \
-      /bin/sh -c "pip install --no-cache-dir -q -r requirements.txt -t python/lib/python3.11/site-packages/"
-    echo "Docker command completed."
-
-    # Create ZIP file
     echo "Creating ZIP file..."
     cd ${local.layer_path}
     zip -m -q -r layer.zip python || echo "No files found to zip"
     echo "ZIP command completed."
-
     EOT
   }
 }

--- a/terraform/modules/lambdas/version.tf
+++ b/terraform/modules/lambdas/version.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.0"
     }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~> 3.0"
+    }
     null = {
       source  = "hashicorp/null"
       version = ">=3.0"


### PR DESCRIPTION
**Why we need this PR**
Lambda layer dependencies were installed with docker run inside a null_resource local-exec. That is a shell sidecar, not Terraform-managed: no volume resource, no container lifecycle, and we own the docker run flags ourselves.
**What was done**
Replaced the docker run part of null_resource.lambda_layer with docker_container
**How that was tested**
terraform init / terraform apply for main_module. Bot responds to messages.