### PR TITLE
feat: EPMCACMAWS-490:Replace null_resource with docker Terraform provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ env/
 # Python-related files
 pip-log.txt
 layer.zip
+**/functions/python/
 pip-delete-this-directory.txt
 .coverage
 .tox/

--- a/terraform/modules/lambdas/README.md
+++ b/terraform/modules/lambdas/README.md
@@ -7,6 +7,7 @@
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7, < 2.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_docker"></a> [docker](#requirement\_docker) | ~> 3.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >=3.0 |
 
 ## Providers
@@ -14,6 +15,7 @@
 | Name | Version |
 | ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_docker"></a> [docker](#provider\_docker) | ~> 3.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | >=3.0 |
 
 ## Modules
@@ -31,6 +33,7 @@
 | [aws_lambda_layer_version.layer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_layer_version) | resource |
 | [aws_lambda_permission.allow_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_s3_bucket_notification.bucket_notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
+| [docker_container.lambda_layer](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs/resources/container) | resource |
 | [null_resource.lambda_layer](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 
 ## Inputs

--- a/terraform/modules/lambdas/README.md
+++ b/terraform/modules/lambdas/README.md
@@ -8,7 +8,6 @@
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7, < 2.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_docker"></a> [docker](#requirement\_docker) | ~> 3.0 |
-| <a name="requirement_null"></a> [null](#requirement\_null) | >=3.0 |
 
 ## Providers
 
@@ -16,7 +15,6 @@
 | ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 | <a name="provider_docker"></a> [docker](#provider\_docker) | ~> 3.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | >=3.0 |
 
 ## Modules
 
@@ -34,7 +32,6 @@
 | [aws_lambda_permission.allow_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_s3_bucket_notification.bucket_notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
 | [docker_container.lambda_layer](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs/resources/container) | resource |
-| [null_resource.lambda_layer](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 
 ## Inputs
 

--- a/terraform/modules/lambdas/main.tf
+++ b/terraform/modules/lambdas/main.tf
@@ -23,7 +23,7 @@ resource "docker_container" "lambda_layer" {
   command = [
     "/bin/sh",
     "-c",
-    "pip install --no-cache-dir -q -r requirements.txt -t python/lib/python3.11/site-packages/ && zip -m -q -r layer.zip python"
+    "rm -rf python && rm -f layer.zip && pip install --no-cache-dir -q -r requirements.txt -t python/lib/python3.11/site-packages/ && python -m zipfile -c layer.zip python && rm -rf python"
   ]
 
   volumes {
@@ -45,6 +45,7 @@ resource "null_resource" "lambda_layer" {
     echo "Creating ZIP file..."
     cd ${local.layer_path}
     zip -m -q -r layer.zip python || echo "No files found to zip"
+    rm -rf python || true
     echo "ZIP command completed."
     EOT
   }

--- a/terraform/modules/lambdas/main.tf
+++ b/terraform/modules/lambdas/main.tf
@@ -3,8 +3,7 @@ locals {
   # Path to the functions directory
   layer_path           = "${path.module}/functions"
   container_layer_path = "/var/task"
-  container_build_path = "/tmp/layer-build"
-  zip_file_path        = "${path.module}/functions/layer.zip" # Path to the output ZIP file
+  zip_file_path        = "${local.layer_path}/layer.zip" # Path to the output ZIP file
   zip_file_exists      = fileexists(local.zip_file_path)
   requirements_sha     = filesha1("${path.module}/functions/requirements.txt")
   # Patterns to exclude from Lambda deployment package
@@ -27,15 +26,14 @@ resource "docker_container" "lambda_layer" {
   attach      = true
   must_run    = false # leave the exited container alone; default true would restart (and re-run pip) every apply
   rm          = false # rm=true removes it on exit, so the next apply recreates it and re-runs pip
-  working_dir = local.container_build_path
+  working_dir = local.container_layer_path
   command = [
     "/bin/sh",
     "-c",
-    "pip install --no-cache-dir -q -r ${local.container_layer_path}/requirements.txt -t python/lib/python3.11/site-packages/ && python -m zipfile -c ${local.container_layer_path}/layer.zip python"
+    "pip install --no-cache-dir -q -r requirements.txt -t /tmp/python/lib/python3.11/site-packages/ && python -m zipfile -c layer.zip /tmp/python"
   ]
 
-  # Host functions dir is only for requirements.txt in and layer.zip out.
-  # python/ stays in the container workdir, not on the volume.
+  # Bind-mount host functions dir: requirements.txt in, layer.zip out. pip writes to /tmp, not the volume.
   volumes {
     host_path      = abspath(local.layer_path)
     container_path = local.container_layer_path
@@ -44,9 +42,8 @@ resource "docker_container" "lambda_layer" {
 
 # Create a new Lambda Layer Version
 resource "aws_lambda_layer_version" "layer" {
-  count    = var.ai_handler_create == "true" ? 1 : 0
-  filename = local.zip_file_path
-  # Hash requirements.txt, not layer.zip — the container rewrites the zip in this apply.
+  count               = var.ai_handler_create == "true" ? 1 : 0
+  filename            = local.zip_file_path
   source_code_hash    = local.requirements_sha
   layer_name          = var.layer_name
   depends_on          = [docker_container.lambda_layer]

--- a/terraform/modules/lambdas/main.tf
+++ b/terraform/modules/lambdas/main.tf
@@ -22,10 +22,10 @@ resource "docker_container" "lambda_layer" {
   count = var.ai_handler_create == "true" ? 1 : 0
   # Recreate the container when layer.zip is missing so pip runs again.
   # Suffix is dropped on the following apply once the zip exists again.
-  name     = "braintf-${var.vcs_repo_name}-lambda-layer-${local.requirements_sha}${local.zip_file_exists ? "" : "-missing-zip"}"
-  image    = "public.ecr.aws/sam/build-python3.11:latest"
-  attach   = true
-  must_run = false # leave the exited container alone; default true would restart (and re-run pip) every apply
+  name        = "braintf-${var.vcs_repo_name}-lambda-layer-${local.requirements_sha}${local.zip_file_exists ? "" : "-missing-zip"}"
+  image       = "public.ecr.aws/sam/build-python3.11:latest"
+  attach      = true
+  must_run    = false # leave the exited container alone; default true would restart (and re-run pip) every apply
   rm          = false # rm=true removes it on exit, so the next apply recreates it and re-runs pip
   working_dir = local.container_build_path
   command = [

--- a/terraform/modules/lambdas/main.tf
+++ b/terraform/modules/lambdas/main.tf
@@ -1,8 +1,8 @@
 #======================= The Lambda function for AI Handler =======================#
 locals {
   # Path to the functions directory
-  layer_path      = "${path.module}/functions"
-  zip_file_path   = "${path.module}/functions/layer.zip" # Path to the output ZIP file
+  layer_path    = "${path.module}/functions"
+  zip_file_path = "${path.module}/functions/layer.zip" # Path to the output ZIP file
   # Patterns to exclude from Lambda deployment package
   lambda_exclude_patterns = [
     "!.*\\.pyc$",

--- a/terraform/modules/lambdas/main.tf
+++ b/terraform/modules/lambdas/main.tf
@@ -1,9 +1,8 @@
 #======================= The Lambda function for AI Handler =======================#
 locals {
   # Path to the functions directory
-  layer_path      = "${path.root}/functions"
+  layer_path      = "${path.module}/functions"
   zip_file_path   = "${path.module}/functions/layer.zip" # Path to the output ZIP file
-  zip_file_exists = fileexists(local.zip_file_path)      # Check if the ZIP file exists
   # Patterns to exclude from Lambda deployment package
   lambda_exclude_patterns = [
     "!.*\\.pyc$",
@@ -14,41 +13,39 @@ locals {
   ]
 }
 
+# Install Python dependencies (replaces `docker run` in null_resource)
+resource "docker_container" "lambda_layer" {
+  count    = var.ai_handler_create == "true" ? 1 : 0
+  name     = "braintf-${var.vcs_repo_name}-lambda-layer"
+  image    = "public.ecr.aws/sam/build-python3.11:latest"
+  attach   = true
+  must_run = false
+  command = [
+    "/bin/sh",
+    "-c",
+    "pip install --no-cache-dir -q -r requirements.txt -t python/lib/python3.11/site-packages/ && zip -m -q -r layer.zip python"
+  ]
+
+  volumes {
+    host_path      = abspath(local.layer_path)
+    container_path = "/var/task"
+  }
+}
+
 # Create a zip file from requirements.txt. Triggers only when the file is updated or ZIP file is missing
 resource "null_resource" "lambda_layer" {
-  count = var.ai_handler_create == "true" ? 1 : 0
+  count      = var.ai_handler_create == "true" ? 1 : 0
+  depends_on = [docker_container.lambda_layer]
   triggers = {
     # Trigger when requirements.txt changes
     requirements = filesha1("${path.module}/functions/requirements.txt")
-    # Trigger when the ZIP file is missing or needs to be recreated
-    zip_missing = local.zip_file_exists ? filesha256(local.zip_file_path) : "true"
   }
-  # The command to install Python dependencies and prepare the build directory
   provisioner "local-exec" {
     command = <<EOT
-    echo "Starting Docker command..."
-
-    # Navigate to the module directory
-    cd ${path.module}
-
-    # Remove previous Python directory and ZIP file if they exist
-    echo "Cleaning up previous Python directory and ZIP file..."
-    rm -rf functions/python || true
-    rm -f functions/layer.zip || true
-
-    # Install required Python libraries into the build directory
-    echo "Installing dependencies..."
-    docker run --platform linux/amd64 --user $(id -u):$(id -g) --rm \
-      -v ${local.layer_path}:/var/task "public.ecr.aws/sam/build-python3.11" \
-      /bin/sh -c "pip install --no-cache-dir -q -r requirements.txt -t python/lib/python3.11/site-packages/"
-    echo "Docker command completed."
-
-    # Create ZIP file
     echo "Creating ZIP file..."
     cd ${local.layer_path}
     zip -m -q -r layer.zip python || echo "No files found to zip"
     echo "ZIP command completed."
-
     EOT
   }
 }

--- a/terraform/modules/lambdas/main.tf
+++ b/terraform/modules/lambdas/main.tf
@@ -1,8 +1,10 @@
 #======================= The Lambda function for AI Handler =======================#
 locals {
   # Path to the functions directory
-  layer_path    = "${path.module}/functions"
-  zip_file_path = "${path.module}/functions/layer.zip" # Path to the output ZIP file
+  layer_path       = "${path.module}/functions"
+  zip_file_path    = "${path.module}/functions/layer.zip" # Path to the output ZIP file
+  zip_file_exists  = fileexists(local.zip_file_path)
+  requirements_sha = filesha1("${path.module}/functions/requirements.txt")
   # Patterns to exclude from Lambda deployment package
   lambda_exclude_patterns = [
     "!.*\\.pyc$",
@@ -16,7 +18,9 @@ locals {
 # Install Python dependencies (replaces `docker run` in null_resource)
 resource "docker_container" "lambda_layer" {
   count    = var.ai_handler_create == "true" ? 1 : 0
-  name     = "braintf-${var.vcs_repo_name}-lambda-layer"
+  # Recreate the container when layer.zip is missing so pip runs again.
+  # Suffix is dropped on the following apply once the zip exists again.
+  name = "braintf-${var.vcs_repo_name}-lambda-layer-${local.requirements_sha}${local.zip_file_exists ? "" : "-missing-zip"}"
   image    = "public.ecr.aws/sam/build-python3.11:latest"
   attach   = true
   must_run = false
@@ -32,22 +36,16 @@ resource "docker_container" "lambda_layer" {
   }
 }
 
-# Create a zip file from requirements.txt. Triggers only when the file is updated or ZIP file is missing
+# Trigger store for layer rebuilds. Zip packaging is done by docker_container.
 resource "null_resource" "lambda_layer" {
   count      = var.ai_handler_create == "true" ? 1 : 0
   depends_on = [docker_container.lambda_layer]
   triggers = {
     # Trigger when requirements.txt changes
-    requirements = filesha1("${path.module}/functions/requirements.txt")
-  }
-  provisioner "local-exec" {
-    command = <<EOT
-    echo "Creating ZIP file..."
-    cd ${local.layer_path}
-    zip -m -q -r layer.zip python || echo "No files found to zip"
-    rm -rf python || true
-    echo "ZIP command completed."
-    EOT
+    requirements = local.requirements_sha
+    # Rebuild when layer.zip is deleted. Do not filesha256 the zip: the container
+    # rewrites it in the same apply, which makes Terraform report an inconsistent result.
+    zip_missing = local.zip_file_exists ? "present" : "missing"
   }
 }
 
@@ -58,7 +56,7 @@ resource "aws_lambda_layer_version" "layer" {
   # Use a static hash from null_resource triggers to avoid dynamic recalculation
   source_code_hash    = null_resource.lambda_layer[0].triggers.requirements
   layer_name          = var.layer_name
-  depends_on          = [null_resource.lambda_layer] # Ensure this waits for ZIP creation
+  depends_on          = [null_resource.lambda_layer] # Waits for docker_container via null_resource
   compatible_runtimes = ["python3.11"]
 }
 

--- a/terraform/modules/lambdas/main.tf
+++ b/terraform/modules/lambdas/main.tf
@@ -17,10 +17,10 @@ locals {
 
 # Install Python dependencies (replaces `docker run` in null_resource)
 resource "docker_container" "lambda_layer" {
-  count    = var.ai_handler_create == "true" ? 1 : 0
+  count = var.ai_handler_create == "true" ? 1 : 0
   # Recreate the container when layer.zip is missing so pip runs again.
   # Suffix is dropped on the following apply once the zip exists again.
-  name = "braintf-${var.vcs_repo_name}-lambda-layer-${local.requirements_sha}${local.zip_file_exists ? "" : "-missing-zip"}"
+  name     = "braintf-${var.vcs_repo_name}-lambda-layer-${local.requirements_sha}${local.zip_file_exists ? "" : "-missing-zip"}"
   image    = "public.ecr.aws/sam/build-python3.11:latest"
   attach   = true
   must_run = false

--- a/terraform/modules/lambdas/main.tf
+++ b/terraform/modules/lambdas/main.tf
@@ -1,10 +1,12 @@
 #======================= The Lambda function for AI Handler =======================#
 locals {
   # Path to the functions directory
-  layer_path       = "${path.module}/functions"
-  zip_file_path    = "${path.module}/functions/layer.zip" # Path to the output ZIP file
-  zip_file_exists  = fileexists(local.zip_file_path)
-  requirements_sha = filesha1("${path.module}/functions/requirements.txt")
+  layer_path           = "${path.module}/functions"
+  container_layer_path = "/var/task"
+  container_build_path = "/tmp/layer-build"
+  zip_file_path        = "${path.module}/functions/layer.zip" # Path to the output ZIP file
+  zip_file_exists      = fileexists(local.zip_file_path)
+  requirements_sha     = filesha1("${path.module}/functions/requirements.txt")
   # Patterns to exclude from Lambda deployment package
   lambda_exclude_patterns = [
     "!.*\\.pyc$",
@@ -15,7 +17,7 @@ locals {
   ]
 }
 
-# Install Python dependencies (replaces `docker run` in null_resource)
+# Install Python dependencies and write layer.zip
 resource "docker_container" "lambda_layer" {
   count = var.ai_handler_create == "true" ? 1 : 0
   # Recreate the container when layer.zip is missing so pip runs again.
@@ -23,29 +25,20 @@ resource "docker_container" "lambda_layer" {
   name     = "braintf-${var.vcs_repo_name}-lambda-layer-${local.requirements_sha}${local.zip_file_exists ? "" : "-missing-zip"}"
   image    = "public.ecr.aws/sam/build-python3.11:latest"
   attach   = true
-  must_run = false
+  must_run = false # leave the exited container alone; default true would restart (and re-run pip) every apply
+  rm          = false # rm=true removes it on exit, so the next apply recreates it and re-runs pip
+  working_dir = local.container_build_path
   command = [
     "/bin/sh",
     "-c",
-    "rm -rf python && rm -f layer.zip && pip install --no-cache-dir -q -r requirements.txt -t python/lib/python3.11/site-packages/ && python -m zipfile -c layer.zip python && rm -rf python"
+    "pip install --no-cache-dir -q -r ${local.container_layer_path}/requirements.txt -t python/lib/python3.11/site-packages/ && python -m zipfile -c ${local.container_layer_path}/layer.zip python"
   ]
 
+  # Host functions dir is only for requirements.txt in and layer.zip out.
+  # python/ stays in the container workdir, not on the volume.
   volumes {
     host_path      = abspath(local.layer_path)
-    container_path = "/var/task"
-  }
-}
-
-# Trigger store for layer rebuilds. Zip packaging is done by docker_container.
-resource "null_resource" "lambda_layer" {
-  count      = var.ai_handler_create == "true" ? 1 : 0
-  depends_on = [docker_container.lambda_layer]
-  triggers = {
-    # Trigger when requirements.txt changes
-    requirements = local.requirements_sha
-    # Rebuild when layer.zip is deleted. Do not filesha256 the zip: the container
-    # rewrites it in the same apply, which makes Terraform report an inconsistent result.
-    zip_missing = local.zip_file_exists ? "present" : "missing"
+    container_path = local.container_layer_path
   }
 }
 
@@ -53,10 +46,10 @@ resource "null_resource" "lambda_layer" {
 resource "aws_lambda_layer_version" "layer" {
   count    = var.ai_handler_create == "true" ? 1 : 0
   filename = local.zip_file_path
-  # Use a static hash from null_resource triggers to avoid dynamic recalculation
-  source_code_hash    = null_resource.lambda_layer[0].triggers.requirements
+  # Hash requirements.txt, not layer.zip — the container rewrites the zip in this apply.
+  source_code_hash    = local.requirements_sha
   layer_name          = var.layer_name
-  depends_on          = [null_resource.lambda_layer] # Waits for docker_container via null_resource
+  depends_on          = [docker_container.lambda_layer]
   compatible_runtimes = ["python3.11"]
 }
 

--- a/terraform/modules/lambdas/version.tf
+++ b/terraform/modules/lambdas/version.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.0"
     }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~> 3.0"
+    }
     null = {
       source  = "hashicorp/null"
       version = ">=3.0"

--- a/terraform/modules/lambdas/version.tf
+++ b/terraform/modules/lambdas/version.tf
@@ -9,9 +9,5 @@ terraform {
       source  = "kreuzwerker/docker"
       version = "~> 3.0"
     }
-    null = {
-      source  = "hashicorp/null"
-      version = ">=3.0"
-    }
   }
 }


### PR DESCRIPTION
**Why we need this PR**

Lambda layer dependencies were installed with docker run inside a null_resource local-exec. That is a shell sidecar, not Terraform-managed: no volume resource, no container lifecycle, and we own the docker run flags ourselves.

**What was done**

Replaced the docker run part of null_resource.lambda_layer with docker_container

**How that was tested**

terraform init / terraform apply for main_module. Bot responds to messages.