### PR TITLE
fix: EPMCACMAWS-502 Fix contradictory approve reactions

### DIFF
--- a/terraform/modules/lambdas/functions/tests/utilities/handlers/test_handlers.py
+++ b/terraform/modules/lambdas/functions/tests/utilities/handlers/test_handlers.py
@@ -266,6 +266,42 @@ def test_handle_approve_command_all_stops_when_repo_check_fails(patched_environm
     assert award_calls == [(webhook_event_command_bot_approve_all_context_github, handlers.FAILURE)]
 
 
+def test_handle_approve_command_all_reports_no_available_files(patched_environment,
+                                                               webhook_event_command_bot_approve_all_context_github,
+                                                               monkeypatch):
+    from utilities import handlers
+
+    commit_calls = []
+    comments = []
+    award_calls = []
+
+    monkeypatch.setattr(
+        "utilities.handlers.add_award_to_note",
+        lambda event, award: award_calls.append((event, award))
+    )
+    monkeypatch.setattr(
+        "utilities.handlers.get_all_files_from_s3_directory",
+        lambda bucket_name, path_to_files: []
+    )
+    monkeypatch.setattr(
+        "utilities.handlers.commit_files_to_branch",
+        lambda event, files, commit_message: commit_calls.append((files, commit_message))
+    )
+    monkeypatch.setattr("utilities.handlers.post_comment", lambda event, body: comments.append(body))
+
+    handlers.handle_approve_command(webhook_event_command_bot_approve_all_context_github, ['all'])
+
+    assert commit_calls == []
+    assert comments == [
+        ':information_source: AI Bot message\n\n'
+        '---\n'
+        '> :no_entry: Not available\\\n'
+        '> There are no corrected files available for approval.\\\n'
+        '> Comment `bot list` to check available files.'
+    ]
+    assert award_calls == [(webhook_event_command_bot_approve_all_context_github, handlers.FAILURE)]
+
+
 def test_handle_approve_command_specific_checks_repo_before_commit(patched_environment,
                                                                    webhook_event_command_bot_approve_all_context_github,
                                                                    monkeypatch):

--- a/terraform/modules/lambdas/functions/tests/utilities/handlers/test_handlers.py
+++ b/terraform/modules/lambdas/functions/tests/utilities/handlers/test_handlers.py
@@ -197,8 +197,12 @@ def test_handle_approve_command_all_uses_generated_commit_message(patched_enviro
 
     commit_calls = []
     delete_calls = []
+    award_calls = []
 
-    monkeypatch.setattr("utilities.handlers.add_award_to_note", lambda event, award: {})
+    monkeypatch.setattr(
+        "utilities.handlers.add_award_to_note",
+        lambda event, award: award_calls.append((event, award))
+    )
     monkeypatch.setattr(
         "utilities.handlers.get_all_files_from_s3_directory",
         lambda bucket_name, path_to_files: [('demo/broken/main.tf', 'content')]
@@ -222,6 +226,7 @@ def test_handle_approve_command_all_uses_generated_commit_message(patched_enviro
         )
     ]
     assert len(delete_calls) == 1
+    assert award_calls == [(webhook_event_command_bot_approve_all_context_github, handlers.SUCCESS)]
 
 
 def test_handle_approve_command_all_stops_when_repo_check_fails(patched_environment,
@@ -231,8 +236,12 @@ def test_handle_approve_command_all_stops_when_repo_check_fails(patched_environm
 
     commit_calls = []
     comments = []
+    award_calls = []
 
-    monkeypatch.setattr("utilities.handlers.add_award_to_note", lambda event, award: {})
+    monkeypatch.setattr(
+        "utilities.handlers.add_award_to_note",
+        lambda event, award: award_calls.append((event, award))
+    )
     monkeypatch.setattr(
         "utilities.handlers.get_all_files_from_s3_directory",
         lambda bucket_name, path_to_files: [('demo/broken/main.tf', 'content')]
@@ -247,7 +256,14 @@ def test_handle_approve_command_all_stops_when_repo_check_fails(patched_environm
     handlers.handle_approve_command(webhook_event_command_bot_approve_all_context_github, ['all'])
 
     assert commit_calls == []
-    assert comments == ['Some approved files do not exist in the repository']
+    assert comments == [
+        ':information_source: AI Bot message\n\n'
+        '---\n'
+        '> :no_entry: Not available\\\n'
+        '> The following files do not exist in the repository: **demo/broken/main.tf**.\\\n'
+        '> BrainTF cannot create new files in the repository; it can only modify existing ones.'
+    ]
+    assert award_calls == [(webhook_event_command_bot_approve_all_context_github, handlers.FAILURE)]
 
 
 def test_handle_approve_command_specific_checks_repo_before_commit(patched_environment,
@@ -257,8 +273,12 @@ def test_handle_approve_command_specific_checks_repo_before_commit(patched_envir
 
     commit_calls = []
     comments = []
+    award_calls = []
 
-    monkeypatch.setattr("utilities.handlers.add_award_to_note", lambda event, award: {})
+    monkeypatch.setattr(
+        "utilities.handlers.add_award_to_note",
+        lambda event, award: award_calls.append((event, award))
+    )
     monkeypatch.setattr(
         "utilities.handlers.get_file_names_from_s3_directory",
         lambda bucket_name, path_to_files: ['demo/broken/main.tf']
@@ -277,7 +297,14 @@ def test_handle_approve_command_specific_checks_repo_before_commit(patched_envir
     handlers.handle_approve_command(webhook_event_command_bot_approve_all_context_github, ['demo/broken/main.tf'])
 
     assert commit_calls == []
-    assert comments == ['Some selected files do not exist in the repository.']
+    assert comments == [
+        ':information_source: AI Bot message\n\n'
+        '---\n'
+        '> :no_entry: Not available\\\n'
+        '> The following files do not exist in the repository: **demo/broken/main.tf**.\\\n'
+        '> BrainTF cannot create new files in the repository; it can only modify existing ones.'
+    ]
+    assert award_calls == [(webhook_event_command_bot_approve_all_context_github, handlers.FAILURE)]
 
 
 def test_handle_approve_command_specific_reports_single_unavailable_file(
@@ -364,8 +391,12 @@ def test_handle_approve_command_specific_deletes_artifacts_after_commit(patched_
 
     commit_calls = []
     delete_calls = []
+    award_calls = []
 
-    monkeypatch.setattr("utilities.handlers.add_award_to_note", lambda event, award: {})
+    monkeypatch.setattr(
+        "utilities.handlers.add_award_to_note",
+        lambda event, award: award_calls.append((event, award))
+    )
     monkeypatch.setattr(
         "utilities.handlers.get_file_names_from_s3_directory",
         lambda bucket_name, path_to_files: ['demo/broken/main.tf', 'demo/broken/validate.tf']
@@ -393,3 +424,4 @@ def test_handle_approve_command_specific_deletes_artifacts_after_commit(patched_
         )
     ]
     assert delete_calls == [('artifacts_bucket', 'artifacts/32/')]
+    assert award_calls == [(webhook_event_command_bot_approve_all_context_github, handlers.SUCCESS)]

--- a/terraform/modules/lambdas/functions/utilities/handlers.py
+++ b/terraform/modules/lambdas/functions/utilities/handlers.py
@@ -12,7 +12,8 @@ from utilities.aws import (delete_files_from_s3,
                            upload_files_to_s3)
 from utilities.exceptions import InvalidEventMetadata
 from utilities.logger import logger
-from utilities.messages import (AI_RESPONSE_MESSAGE, LIST_FILES_MESSAGE,
+from utilities.messages import (AI_RESPONSE_MESSAGE, FILES_NOT_IN_REPO_MESSAGE,
+                                LIST_FILES_MESSAGE,
                                 UNAVAILABLE_APPROVAL_FILES_MESSAGE)
 from utilities.parsers import parse_hcl_blocks
 from utilities.vcs import (FAILURE, SUCCESS, add_award_to_note,
@@ -224,7 +225,6 @@ def handle_approve_command(event: Dict[str, Any], rest_comment: List[str]) -> No
     logger.info('Processing approve command...')
     if rest_comment[0] in {'*', 'all'}:
         logger.info('Approving all corrected files...')
-        add_award_to_note(event, SUCCESS)
 
         merge_or_pull_req_id = event.get('metadata', {}).get('merge_or_pull_req_id')
         path_to_files_for_approval = f"{config.path_to_artifacts}/{merge_or_pull_req_id}/"
@@ -237,17 +237,20 @@ def handle_approve_command(event: Dict[str, Any], rest_comment: List[str]) -> No
         if file_names_with_content:
             logger.info('Committing all approved corrected files...')
 
-            # Check if files exist in VCS repository
             files_to_check: list[str] = [file_key for file_key, _ in file_names_with_content]
 
             if not check_files_exist_in_repo(event, files_to_check):
                 logger.warning('Some approved files do not exist in the repository.')
                 add_award_to_note(event, FAILURE)
-                post_comment(event, 'Some approved files do not exist in the repository')
+                post_comment(
+                    event,
+                    FILES_NOT_IN_REPO_MESSAGE.format(files=', '.join(files_to_check))
+                )
                 return
 
             commit_message = build_approval_commit_message(files_to_check)
             commit_files_to_branch(event, file_names_with_content, commit_message)
+            add_award_to_note(event, SUCCESS)
             delete_files_from_s3(config.artifacts_bucket, path_to_files_for_approval)
     else:
         logger.info('Approving specific rest_comment...')
@@ -265,12 +268,14 @@ def handle_approve_command(event: Dict[str, Any], rest_comment: List[str]) -> No
                 UNAVAILABLE_APPROVAL_FILES_MESSAGE.format(unavailable_files=unavailable_files)
             )
         else:
-            add_award_to_note(event, SUCCESS)
-
             if not check_files_exist_in_repo(event, rest_comment):
                 logger.warning('Some selected files do not exist in the repository.')
                 add_award_to_note(event, FAILURE)
-                post_comment(event, 'Some selected files do not exist in the repository.')
+                selected_files = ', '.join(rest_comment)
+                post_comment(
+                    event,
+                    FILES_NOT_IN_REPO_MESSAGE.format(files=selected_files)
+                )
                 return
 
             files_names_with_content: list[tuple[str, str]] = get_particular_files_from_s3_directory(
@@ -279,4 +284,5 @@ def handle_approve_command(event: Dict[str, Any], rest_comment: List[str]) -> No
 
             commit_message = build_approval_commit_message(rest_comment)
             commit_files_to_branch(event, files_names_with_content, commit_message)
+            add_award_to_note(event, SUCCESS)
             delete_files_from_s3(config.artifacts_bucket, path_to_files_for_approval)

--- a/terraform/modules/lambdas/functions/utilities/handlers.py
+++ b/terraform/modules/lambdas/functions/utilities/handlers.py
@@ -13,7 +13,7 @@ from utilities.aws import (delete_files_from_s3,
 from utilities.exceptions import InvalidEventMetadata
 from utilities.logger import logger
 from utilities.messages import (AI_RESPONSE_MESSAGE, FILES_NOT_IN_REPO_MESSAGE,
-                                LIST_FILES_MESSAGE,
+                                LIST_FILES_MESSAGE, NO_APPROVAL_FILES_MESSAGE,
                                 UNAVAILABLE_APPROVAL_FILES_MESSAGE)
 from utilities.parsers import parse_hcl_blocks
 from utilities.vcs import (FAILURE, SUCCESS, add_award_to_note,
@@ -252,6 +252,10 @@ def handle_approve_command(event: Dict[str, Any], rest_comment: List[str]) -> No
             commit_files_to_branch(event, file_names_with_content, commit_message)
             add_award_to_note(event, SUCCESS)
             delete_files_from_s3(config.artifacts_bucket, path_to_files_for_approval)
+        else:
+            logger.warning('No corrected files are available for approval.')
+            add_award_to_note(event, FAILURE)
+            post_comment(event, NO_APPROVAL_FILES_MESSAGE)
     else:
         logger.info('Approving specific rest_comment...')
         merge_or_pull_req_id = event.get('metadata', {}).get('merge_or_pull_req_id')

--- a/terraform/modules/lambdas/functions/utilities/messages.py
+++ b/terraform/modules/lambdas/functions/utilities/messages.py
@@ -63,6 +63,15 @@ FILES_NOT_IN_REPO_MESSAGE: str = """
 > BrainTF cannot create new files in the repository; it can only modify existing ones.
 """.lstrip().removesuffix("\n")
 
+NO_APPROVAL_FILES_MESSAGE: str = """
+:information_source: AI Bot message
+
+---
+> :no_entry: Not available\\
+> There are no corrected files available for approval.\\
+> Comment `bot list` to check available files.
+""".lstrip().removesuffix("\n")
+
 AI_RESPONSE_MESSAGE: str = """
 :information_source: AI Bot message
 

--- a/terraform/modules/lambdas/functions/utilities/messages.py
+++ b/terraform/modules/lambdas/functions/utilities/messages.py
@@ -54,6 +54,15 @@ UNAVAILABLE_APPROVAL_FILES_MESSAGE: str = """
 > Comment `bot list` to see corrected files currently available for approval.
 """.lstrip().removesuffix("\n")
 
+FILES_NOT_IN_REPO_MESSAGE: str = """
+:information_source: AI Bot message
+
+---
+> :no_entry: Not available\\
+> The following files do not exist in the repository: **{files}**.\\
+> BrainTF cannot create new files in the repository; it can only modify existing ones.
+""".lstrip().removesuffix("\n")
+
 AI_RESPONSE_MESSAGE: str = """
 :information_source: AI Bot message
 


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce? -->
- [ ] New feature (feat)
- [x] Bug fix (fix)
- [ ] Documentation (docs)
- [ ] Refactor (refactor)
- [ ] Chore (chore)

## Why we need this PR
- Approval commands could show contradictory feedback by adding a success reaction before the approval flow actually completed.
- Users could see a success reaction even when approved generated files were missing from the repository.
- `bot approve all` could produce no clear feedback when no corrected files were available for approval.

## What was done
- Add failure feedback when approved generated files do not exist in the repository.
- Add failure feedback when `bot approve all` is used but no corrected files are available for approval.
- Keep success reactions only after `commit_files_to_branch(...)` is called successfully.
- Add reusable messages for:
  - files missing from the repository
  - no corrected files available for approval
- Extend handler tests to verify reaction status, comments, and commit-skipping behavior for failure paths.

## How it was tested
- [x] Manually
- [x] Automatically
