### PR TITLE
fix: EPMCACMAWS-500 Remove redundant repo PR/MR fetches

### DIFF
--- a/terraform/modules/lambdas/functions/tests/utilities/vcs/test_github_functions.py
+++ b/terraform/modules/lambdas/functions/tests/utilities/vcs/test_github_functions.py
@@ -275,48 +275,6 @@ def test_post_help_message_github_success(patched_config_gitlab, ssm_setup, mock
     assert mock_gh_class.instance.repo.pr.last_body == expected_body
 
 
-def test_get_pr_source_branch_name_success(patched_config_gitlab, ssm_setup, mock_github):
-    from utilities.vcs.github_functions import (_get_github_client,
-                                                get_pr_source_branch_name)
-    _get_github_client.cache_clear()
-    mock_gh_class, _ = mock_github
-    mock_gh_class.instance.repo.pr.head.ref = "test-branch"
-
-    branch_name = get_pr_source_branch_name("owner/repo", 123)
-
-    assert branch_name == "test-branch"
-    assert mock_gh_class.instance.get_repo_called == 1
-    assert mock_gh_class.instance.last_repo_name == "owner/repo"
-    assert mock_gh_class.instance.repo.get_pull_called == 1
-    assert mock_gh_class.instance.repo.last_pull_number == 123
-
-
-@pytest.mark.parametrize("exception_class, match_msg", [
-    (BadCredentialsException, "Auth failed"),
-    (UnknownObjectException, "Not found"),
-    (GithubException, "API error"),
-    (Exception, "Unexpected error")
-])
-def test_get_pr_source_branch_name_failures(patched_config_gitlab, mock_github, monkeypatch, exception_class,
-                                            match_msg):
-    from utilities.vcs.github_functions import (_get_github_client,
-                                                get_pr_source_branch_name)
-    _get_github_client.cache_clear()
-    mock_gh_class, _ = mock_github
-
-    exc = create_github_exception(exception_class, match_msg)
-
-    mock_gh_class.instance.repo.side_effect_get_pull = exc
-
-    mock_logger = MockLogger()
-    monkeypatch.setattr("utilities.vcs.github_functions.logger", mock_logger)
-
-    with pytest.raises(exception_class):
-        get_pr_source_branch_name("owner/repo", 123)
-
-    assert mock_logger.error_called == 1
-
-
 def test_add_reaction_to_pr_comment_github_success(patched_config_gitlab, ssm_setup, mock_github):
     from utilities.vcs.github_functions import (
         _get_github_client, add_reaction_to_pr_comment_github)

--- a/terraform/modules/lambdas/functions/tests/utilities/vcs/test_github_functions.py
+++ b/terraform/modules/lambdas/functions/tests/utilities/vcs/test_github_functions.py
@@ -446,12 +446,14 @@ def test_check_files_exist_in_repo_github_success(patched_config_gitlab, ssm_set
     result = check_files_exist_in_repo_github(event, file_paths)
     assert result is True
     assert mock_gh_class.instance.repo.get_contents_called == 2
-    assert mock_gh_class.instance.get_repo_called == 2
+    assert mock_gh_class.instance.get_repo_called == 1
+    assert mock_gh_class.instance.repo.get_pull_called == 1
     assert mock_gh_class.instance.repo.last_ref == "feature-branch"
 
     # Case 2: Some files missing
     mock_gh_class.instance.repo.get_contents_called = 0
     mock_gh_class.instance.get_repo_called = 0
+    mock_gh_class.instance.repo.get_pull_called = 0
     mock_gh_class.instance.repo.side_effect_get_contents = {
         "file2.txt": UnknownObjectException(404, {"message": "Not found"}, {})
     }
@@ -459,7 +461,8 @@ def test_check_files_exist_in_repo_github_success(patched_config_gitlab, ssm_set
     result = check_files_exist_in_repo_github(event, file_paths)
     assert result is False
     assert mock_gh_class.instance.repo.get_contents_called == 2
-    assert mock_gh_class.instance.get_repo_called == 2
+    assert mock_gh_class.instance.get_repo_called == 1
+    assert mock_gh_class.instance.repo.get_pull_called == 1
 
 
 @pytest.mark.parametrize("exception_class, match_msg", [
@@ -475,15 +478,11 @@ def test_check_files_exist_in_repo_github_failures(patched_config_gitlab, mock_g
     _get_github_client.cache_clear()
     mock_gh_class, _ = mock_github
 
-    # Mock get_pr_source_branch_name to return a dummy branch and avoid its own logging
-    monkeypatch.setattr("utilities.vcs.github_functions.get_pr_source_branch_name", lambda r, p: "main")
-
     if exception_class in (BadCredentialsException, UnknownObjectException, GithubException):
         exc = exception_class(401 if exception_class == BadCredentialsException else 404, {"message": match_msg}, {})
     else:
         exc = exception_class(match_msg)
 
-    # Put the exception on get_repo to trigger the outer catch block in check_files_exist_in_repo_github
     mock_gh_class.instance.side_effect_get_repo = exc
 
     mock_logger = MockLogger()
@@ -537,8 +536,10 @@ class MockRepoCommit:
         self.create_git_tree_called = 0
         self.create_git_commit_called = 0
         self.git_ref = MockGitRef("initial-sha")
+        self.last_ref = None
 
     def get_git_ref(self, ref):
+        self.last_ref = ref
         return self.git_ref
 
     def get_git_commit(self, sha):
@@ -594,6 +595,9 @@ def test_commit_files_to_branch_github_success(patched_config_gitlab, mock_githu
 
     commit_files_to_branch_github(event, files, "msg")
 
+    assert mock_gh_class.instance.get_repo_called == 1
+    assert mock_gh_class.instance.repo.get_pull_called == 1
+    assert mock_gh_class.instance.repo.commit_mock.last_ref == "heads/feature-branch"
     assert mock_gh_class.instance.repo.commit_mock.create_git_blob_called == 1
     assert mock_gh_class.instance.repo.commit_mock.create_git_tree_called == 1
     assert mock_gh_class.instance.repo.commit_mock.create_git_commit_called == 1

--- a/terraform/modules/lambdas/functions/tests/utilities/vcs/test_github_functions.py
+++ b/terraform/modules/lambdas/functions/tests/utilities/vcs/test_github_functions.py
@@ -131,11 +131,18 @@ class MockLogger:
         self.error_called = 0
         self.warning_called = 0
 
-    def error(self, msg):
+    def error(self, _msg):
         self.error_called += 1
 
-    def warning(self, msg):
+    def warning(self, _msg):
         self.warning_called += 1
+
+
+def create_github_exception(exception_class, message):
+    if exception_class in (BadCredentialsException, UnknownObjectException, GithubException):
+        status = 401 if exception_class == BadCredentialsException else 404
+        return exception_class(status, {"message": message}, {})
+    return exception_class(message)
 
 
 @pytest.fixture
@@ -227,12 +234,7 @@ def test_post_pr_comment_github_failures(patched_config_gitlab, mock_github, mon
     _get_github_client.cache_clear()
     mock_gh_class, _ = mock_github
 
-    # Setup failure at create_issue_comment
-    if exception_class in (BadCredentialsException, UnknownObjectException, GithubException):
-        # PyGithub exceptions usually take (status, data, headers)
-        exc = exception_class(401 if exception_class == BadCredentialsException else 404, {"message": match_msg}, {})
-    else:
-        exc = exception_class(match_msg)
+    exc = create_github_exception(exception_class, match_msg)
 
     mock_gh_class.instance.repo.pr.side_effect_create_comment = exc
 
@@ -253,9 +255,9 @@ def test_post_pr_comment_github_failures(patched_config_gitlab, mock_github, mon
 
 
 def test_post_help_message_github_success(patched_config_gitlab, ssm_setup, mock_github):
+    from utilities.messages import HELP_MESSAGE
     from utilities.vcs.github_functions import (_get_github_client,
                                                 post_help_message_github)
-    from utilities.messages import HELP_MESSAGE
     _get_github_client.cache_clear()
     mock_gh_class, _ = mock_github
 
@@ -302,10 +304,7 @@ def test_get_pr_source_branch_name_failures(patched_config_gitlab, mock_github, 
     _get_github_client.cache_clear()
     mock_gh_class, _ = mock_github
 
-    if exception_class in (BadCredentialsException, UnknownObjectException, GithubException):
-        exc = exception_class(401 if exception_class == BadCredentialsException else 404, {"message": match_msg}, {})
-    else:
-        exc = exception_class(match_msg)
+    exc = create_github_exception(exception_class, match_msg)
 
     mock_gh_class.instance.repo.side_effect_get_pull = exc
 
@@ -319,8 +318,8 @@ def test_get_pr_source_branch_name_failures(patched_config_gitlab, mock_github, 
 
 
 def test_add_reaction_to_pr_comment_github_success(patched_config_gitlab, ssm_setup, mock_github):
-    from utilities.vcs.github_functions import (_get_github_client,
-                                                add_reaction_to_pr_comment_github)
+    from utilities.vcs.github_functions import (
+        _get_github_client, add_reaction_to_pr_comment_github)
     _get_github_client.cache_clear()
     mock_gh_class, _ = mock_github
 
@@ -354,15 +353,12 @@ def test_add_reaction_to_pr_comment_github_success(patched_config_gitlab, ssm_se
 ])
 def test_add_reaction_to_pr_comment_github_failures(patched_config_gitlab, mock_github, monkeypatch, exception_class,
                                                     match_msg):
-    from utilities.vcs.github_functions import (_get_github_client,
-                                                add_reaction_to_pr_comment_github)
+    from utilities.vcs.github_functions import (
+        _get_github_client, add_reaction_to_pr_comment_github)
     _get_github_client.cache_clear()
     mock_gh_class, _ = mock_github
 
-    if exception_class in (BadCredentialsException, UnknownObjectException, GithubException):
-        exc = exception_class(401 if exception_class == BadCredentialsException else 404, {"message": match_msg}, {})
-    else:
-        exc = exception_class(match_msg)
+    exc = create_github_exception(exception_class, match_msg)
 
     mock_gh_class.instance.repo.pr.side_effect_get_issue_comment = exc
 
@@ -412,10 +408,7 @@ def test_get_last_commit_sha_github_failures(patched_config_gitlab, mock_github,
     _get_github_client.cache_clear()
     mock_gh_class, _ = mock_github
 
-    if exception_class in (BadCredentialsException, UnknownObjectException, GithubException):
-        exc = exception_class(401 if exception_class == BadCredentialsException else 404, {"message": match_msg}, {})
-    else:
-        exc = exception_class(match_msg)
+    exc = create_github_exception(exception_class, match_msg)
 
     mock_gh_class.instance.repo.side_effect_get_pull = exc
 
@@ -429,8 +422,8 @@ def test_get_last_commit_sha_github_failures(patched_config_gitlab, mock_github,
 
 
 def test_check_files_exist_in_repo_github_success(patched_config_gitlab, ssm_setup, mock_github):
-    from utilities.vcs.github_functions import (_get_github_client,
-                                                check_files_exist_in_repo_github)
+    from utilities.vcs.github_functions import (
+        _get_github_client, check_files_exist_in_repo_github)
     _get_github_client.cache_clear()
     mock_gh_class, _ = mock_github
 
@@ -473,15 +466,12 @@ def test_check_files_exist_in_repo_github_success(patched_config_gitlab, ssm_set
 ])
 def test_check_files_exist_in_repo_github_failures(patched_config_gitlab, mock_github, monkeypatch, exception_class,
                                                    match_msg):
-    from utilities.vcs.github_functions import (_get_github_client,
-                                                check_files_exist_in_repo_github)
+    from utilities.vcs.github_functions import (
+        _get_github_client, check_files_exist_in_repo_github)
     _get_github_client.cache_clear()
     mock_gh_class, _ = mock_github
 
-    if exception_class in (BadCredentialsException, UnknownObjectException, GithubException):
-        exc = exception_class(401 if exception_class == BadCredentialsException else 404, {"message": match_msg}, {})
-    else:
-        exc = exception_class(match_msg)
+    exc = create_github_exception(exception_class, match_msg)
 
     mock_gh_class.instance.side_effect_get_repo = exc
 
@@ -542,18 +532,19 @@ class MockRepoCommit:
         self.last_ref = ref
         return self.git_ref
 
-    def get_git_commit(self, sha):
+    @staticmethod
+    def get_git_commit(sha):
         return MockGitCommit(sha)
 
-    def create_git_blob(self, content, encoding):
+    def create_git_blob(self, _content, _encoding):
         self.create_git_blob_called += 1
         return MockGitBlob(f"blob-sha-{self.create_git_blob_called}")
 
-    def create_git_tree(self, tree_elements, base_tree=None):
+    def create_git_tree(self, _tree_elements, _base_tree=None):
         self.create_git_tree_called += 1
         return MockGitTree("tree-sha")
 
-    def create_git_commit(self, message, tree, parents):
+    def create_git_commit(self, _message, _tree, _parents):
         self.create_git_commit_called += 1
         return MockGitCommit("new-commit-sha")
 
@@ -583,7 +574,8 @@ class MockRepoWithCommit(MockRepo):
 
 
 def test_commit_files_to_branch_github_success(patched_config_gitlab, mock_github, monkeypatch):
-    from utilities.vcs.github_functions import commit_files_to_branch_github, _get_github_client
+    from utilities.vcs.github_functions import (_get_github_client,
+                                                commit_files_to_branch_github)
     _get_github_client.cache_clear()
 
     # Use the extended mock repo
@@ -612,16 +604,14 @@ def test_commit_files_to_branch_github_success(patched_config_gitlab, mock_githu
 ])
 def test_commit_files_to_branch_github_failures(patched_config_gitlab, mock_github, monkeypatch, exception_class,
                                                 match_msg):
-    from utilities.vcs.github_functions import commit_files_to_branch_github, _get_github_client
+    from utilities.vcs.github_functions import (_get_github_client,
+                                                commit_files_to_branch_github)
     _get_github_client.cache_clear()
 
     mock_gh_class, _ = mock_github
     mock_gh_class.instance.repo = MockRepoWithCommit()
 
-    if exception_class in (BadCredentialsException, UnknownObjectException, GithubException):
-        exc = exception_class(401 if exception_class == BadCredentialsException else 404, {"message": match_msg}, {})
-    else:
-        exc = exception_class(match_msg)
+    exc = create_github_exception(exception_class, match_msg)
 
     mock_gh_class.instance.repo.side_effect_get_ref = exc
 
@@ -639,14 +629,15 @@ def test_commit_files_to_branch_github_failures(patched_config_gitlab, mock_gith
 # --- New test for get_all_tf_files_from_paths_list_github ---
 
 class MockContentItem:
-    def __init__(self, path, type, content):
+    def __init__(self, path, content_type, content):
         self.path = path
-        self.type = type
+        self.type = content_type
         self.decoded_content = content.encode("utf-8")
 
 
 def test_get_all_tf_files_from_paths_list_github_success(patched_config_gitlab, mock_github, monkeypatch):
-    from utilities.vcs.github_functions import get_all_tf_files_from_paths_list_github, _get_github_client
+    from utilities.vcs.github_functions import (
+        _get_github_client, get_all_tf_files_from_paths_list_github)
     _get_github_client.cache_clear()
 
     mock_gh_class, _ = mock_github
@@ -656,7 +647,7 @@ def test_get_all_tf_files_from_paths_list_github_success(patched_config_gitlab, 
     item2 = MockContentItem("dir/vars.txt", "file", "other")
     item3 = MockContentItem("dir/other.tf", "file", "content2")
 
-    def get_contents_side_effect(path, ref=None):
+    def get_contents_side_effect(_path, _ref=None):
         return [item1, item2, item3]
 
     mock_gh_class.instance.repo.side_effect_get_contents = get_contents_side_effect
@@ -674,8 +665,7 @@ def test_get_all_tf_files_from_paths_list_github_success(patched_config_gitlab, 
 def test_get_all_tf_files_from_paths_list_github_accepts_single_content_file(
         patched_config_gitlab, mock_github):
     from utilities.vcs.github_functions import (
-        _get_github_client, get_all_tf_files_from_paths_list_github
-    )
+        _get_github_client, get_all_tf_files_from_paths_list_github)
     _get_github_client.cache_clear()
 
     mock_gh_class, _ = mock_github
@@ -691,7 +681,8 @@ def test_get_all_tf_files_from_paths_list_github_accepts_single_content_file(
 
 
 def test_get_all_tf_files_from_paths_list_github_exception(patched_config_gitlab, mock_github, monkeypatch):
-    from utilities.vcs.github_functions import get_all_tf_files_from_paths_list_github, _get_github_client
+    from utilities.vcs.github_functions import (
+        _get_github_client, get_all_tf_files_from_paths_list_github)
     _get_github_client.cache_clear()
 
     mock_gh_class, _ = mock_github

--- a/terraform/modules/lambdas/functions/tests/utilities/vcs/test_github_functions.py
+++ b/terraform/modules/lambdas/functions/tests/utilities/vcs/test_github_functions.py
@@ -667,6 +667,25 @@ def test_get_all_tf_files_from_paths_list_github_success(patched_config_gitlab, 
     assert results[1] == ("dir/other.tf", "content2")
 
 
+def test_get_all_tf_files_from_paths_list_github_accepts_single_content_file(
+        patched_config_gitlab, mock_github):
+    from utilities.vcs.github_functions import (
+        _get_github_client, get_all_tf_files_from_paths_list_github
+    )
+    _get_github_client.cache_clear()
+
+    mock_gh_class, _ = mock_github
+    mock_gh_class.instance.repo.side_effect_get_contents = lambda path, ref: (
+        MockContentItem("main.tf", "file", "content")
+    )
+
+    event = {"metadata": {"repo_id_or_name": "owner/repo", "source_branch": "main"}}
+
+    assert get_all_tf_files_from_paths_list_github(event, ["main.tf"]) == [
+        ("main.tf", "content")
+    ]
+
+
 def test_get_all_tf_files_from_paths_list_github_exception(patched_config_gitlab, mock_github, monkeypatch):
     from utilities.vcs.github_functions import get_all_tf_files_from_paths_list_github, _get_github_client
     _get_github_client.cache_clear()

--- a/terraform/modules/lambdas/functions/tests/utilities/vcs/test_gitlab_functions.py
+++ b/terraform/modules/lambdas/functions/tests/utilities/vcs/test_gitlab_functions.py
@@ -169,7 +169,7 @@ class MockLogger:
 @pytest.fixture
 def mock_gitlab(monkeypatch):
     mock_gl_class = MockGitlabClass()
-    monkeypatch.setattr("utilities.vcs.gitlab_functions.gitlab.Gitlab", mock_gl_class)
+    monkeypatch.setattr("utilities.vcs.gitlab_functions.Gitlab", mock_gl_class)
     return mock_gl_class
 
 

--- a/terraform/modules/lambdas/functions/tests/utilities/vcs/test_gitlab_functions.py
+++ b/terraform/modules/lambdas/functions/tests/utilities/vcs/test_gitlab_functions.py
@@ -54,12 +54,13 @@ class MockProject:
         self.repository_tree_return_by_path = {}
         self.repository_tree_side_effect_by_path = {}
 
-    def repository_tree(self, path=None, ref=None, recursive=False):
+    def repository_tree(self, path=None, ref=None, recursive=False, get_all=False):
         self.repository_tree_called += 1
         self.repository_tree_calls.append({
             "path": path,
             "ref": ref,
             "recursive": recursive,
+            "get_all": get_all,
         })
         if path in self.repository_tree_side_effect_by_path:
             raise self.repository_tree_side_effect_by_path[path]
@@ -307,52 +308,6 @@ def test_post_help_message_gitlab_success(patched_config_gitlab, ssm_setup, mock
     assert mock_gitlab.instance.projects.project.mergerequests.mr.notes.last_data == {"body": expected_help_message}
 
 
-def test_get_mr_source_branch_name_success(patched_config_gitlab, ssm_setup, mock_gitlab):
-    from utilities.vcs.gitlab_functions import (_get_gitlab_client,
-                                                get_mr_source_branch_name)
-    _get_gitlab_client.cache_clear()
-
-    project_id = "group/project"
-    mr_id = 456
-    mock_gitlab.instance.projects.project.mergerequests.mr.source_branch = "test-branch"
-
-    result = get_mr_source_branch_name(project_id, mr_id)
-
-    assert result == "test-branch"
-    assert mock_gitlab.instance.projects.get_called == 1
-    assert mock_gitlab.instance.projects.last_id == project_id
-    assert mock_gitlab.instance.projects.project.mergerequests.get_called == 1
-    assert mock_gitlab.instance.projects.project.mergerequests.last_iid == mr_id
-
-
-@pytest.mark.parametrize("exception_class, match_msg, failure_at", [
-    (gitlab.GitlabAuthenticationError, "Auth failed", "project"),
-    (gitlab.GitlabGetError, "Not found", "mr"),
-    (Exception, "Unexpected error", "project")
-])
-def test_get_mr_source_branch_name_failures(patched_config_gitlab, mock_gitlab, monkeypatch, exception_class, match_msg, failure_at):
-    from utilities.vcs.gitlab_functions import (_get_gitlab_client,
-                                                get_mr_source_branch_name)
-    _get_gitlab_client.cache_clear()
-
-    if exception_class in (gitlab.GitlabAuthenticationError, gitlab.GitlabGetError):
-        exc = exception_class(match_msg, response_code=401 if exception_class == gitlab.GitlabAuthenticationError else 404)
-    else:
-        exc = exception_class(match_msg)
-
-    if failure_at == "project":
-        mock_gitlab.instance.projects.side_effect_get = exc
-    else:
-        mock_gitlab.instance.projects.project.mergerequests.side_effect_get = exc
-
-    mock_logger = MockLogger()
-    monkeypatch.setattr("utilities.vcs.gitlab_functions.logger", mock_logger)
-
-    with pytest.raises(exception_class):
-        get_mr_source_branch_name("group/project", 456)
-
-    assert mock_logger.error_called >= 1
-
 # --- New tests for add_award_to_note_gitlab ---
 
 class MockAwardEmojis:
@@ -476,6 +431,9 @@ def test_check_files_exist_in_repo_gitlab_all_exist(patched_config_gitlab, mock_
     assert project.repository_tree_called == 2
     assert project.repository_tree_calls[0]["ref"] == "feature-branch"
     assert project.repository_tree_calls[1]["ref"] == "feature-branch"
+    # Without get_all the first page only would be compared against the expected
+    # files, and anything beyond it reported as missing.
+    assert all(call["get_all"] is True for call in project.repository_tree_calls)
 
 
 def test_check_files_exist_in_repo_gitlab_missing_file_returns_false(patched_config_gitlab, mock_gitlab):
@@ -693,6 +651,9 @@ def test_get_all_tf_files_from_paths_list_gitlab_success(patched_config_gitlab, 
         ("dir2/vars.tf", 'variable "name" {}'),
     ]
     assert project.files.get_called == 2
+    # Without get_all the tree is truncated to the first page and Terraform files
+    # beyond it never reach the prompt.
+    assert all(call["get_all"] is True for call in project.repository_tree_calls)
 
 
 def test_get_all_tf_files_from_paths_list_gitlab_no_tf_files(patched_config_gitlab, mock_gitlab):

--- a/terraform/modules/lambdas/functions/tests/utilities/vcs/test_gitlab_functions.py
+++ b/terraform/modules/lambdas/functions/tests/utilities/vcs/test_gitlab_functions.py
@@ -466,6 +466,8 @@ def test_check_files_exist_in_repo_gitlab_all_exist(patched_config_gitlab, mock_
     result = check_files_exist_in_repo_gitlab(event, ["dir1/a.tf", "root.tf"])
 
     assert result is True
+    assert mock_gitlab.instance.projects.get_called == 1
+    assert project.mergerequests.get_called == 1
     assert project.repository_tree_called == 2
     assert project.repository_tree_calls[0]["ref"] == "feature-branch"
     assert project.repository_tree_calls[1]["ref"] == "feature-branch"
@@ -490,6 +492,8 @@ def test_check_files_exist_in_repo_gitlab_missing_file_returns_false(patched_con
     result = check_files_exist_in_repo_gitlab(event, ["dir1/missing.tf"])
 
     assert result is False
+    assert mock_gitlab.instance.projects.get_called == 1
+    assert project.mergerequests.get_called == 1
 
 
 def test_check_files_exist_in_repo_gitlab_missing_directory_returns_false(patched_config_gitlab, mock_gitlab):
@@ -511,10 +515,12 @@ def test_check_files_exist_in_repo_gitlab_missing_directory_returns_false(patche
     result = check_files_exist_in_repo_gitlab(event, ["missing-dir/file1.tf", "missing-dir/file2.tf"])
 
     assert result is False
+    assert mock_gitlab.instance.projects.get_called == 1
+    assert project.mergerequests.get_called == 1
 
 
 @pytest.mark.parametrize("exception_class, match_msg, failure_stage", [
-    (gitlab.GitlabAuthenticationError, "Auth failed", "branch"),
+    (gitlab.GitlabAuthenticationError, "Auth failed", "project"),
     (gitlab.GitlabGetError, "API failed", "tree"),
     (Exception, "Unexpected error", "tree"),
 ])
@@ -539,7 +545,7 @@ def test_check_files_exist_in_repo_gitlab_failures(
     else:
         exc = exception_class(match_msg)
 
-    if failure_stage == "branch":
+    if failure_stage == "project":
         mock_gitlab.instance.projects.side_effect_get = exc
     else:
         mock_gitlab.instance.projects.project.repository_tree_side_effect_by_path = {"dir1": exc}
@@ -572,6 +578,8 @@ def test_commit_files_to_branch_gitlab_success(patched_config_gitlab, mock_gitla
 
     result = commit_files_to_branch_gitlab(event, file_paths_with_content, "update tf files")
 
+    assert mock_gitlab.instance.projects.get_called == 1
+    assert mock_gitlab.instance.projects.project.mergerequests.get_called == 1
     assert result["branch"] == "feature-branch"
     assert result["commit_message"] == "update tf files"
     assert result["actions"] == [

--- a/terraform/modules/lambdas/functions/tests/utilities/vcs/test_gitlab_functions.py
+++ b/terraform/modules/lambdas/functions/tests/utilities/vcs/test_gitlab_functions.py
@@ -73,9 +73,9 @@ class MockProjects:
         self.project = MockProject()
         self.side_effect_get = None
 
-    def get(self, id):
+    def get(self, project_id):
         self.get_called += 1
-        self.last_id = id
+        self.last_id = project_id
         if self.side_effect_get:
             raise self.side_effect_get
         return self.project
@@ -156,14 +156,16 @@ class MockLogger:
     def __init__(self):
         self.error_called = 0
 
-    def error(self, msg):
+    def error(self, _msg):
         self.error_called += 1
 
-    def info(self, msg):
-        return None
+    @staticmethod
+    def info(_msg):
+        pass
 
-    def debug(self, msg):
-        return None
+    @staticmethod
+    def debug(_msg):
+        pass
 
 
 @pytest.fixture
@@ -365,8 +367,8 @@ class MockAwardEmojis:
         if self.side_effect_create:
             raise self.side_effect_create
         class MockAward:
-            def __init__(self, data):
-                self.attributes = data
+            def __init__(self, award_data):
+                self.attributes = award_data
         return MockAward(data)
 
 class MockNoteWithAwards(MockNote):
@@ -382,15 +384,16 @@ class MockNotesWithAwards(MockNotes):
         self.get_called = 0
         self.last_comment_id = None
 
-    def get(self, id):
+    def get(self, comment_id):
         self.get_called += 1
-        self.last_comment_id = id
+        self.last_comment_id = comment_id
         if self.side_effect_get:
             raise self.side_effect_get
         return self.note
 
 def test_add_award_to_note_gitlab_success(patched_config_gitlab, mock_gitlab, monkeypatch):
-    from utilities.vcs.gitlab_functions import add_award_to_note_gitlab, _get_gitlab_client
+    from utilities.vcs.gitlab_functions import (_get_gitlab_client,
+                                                add_award_to_note_gitlab)
     _get_gitlab_client.cache_clear()
     
     # Inject mock with awardemojis
@@ -417,7 +420,8 @@ def test_add_award_to_note_gitlab_success(patched_config_gitlab, mock_gitlab, mo
     (Exception, "Unexpected error")
 ])
 def test_add_award_to_note_gitlab_failures(patched_config_gitlab, mock_gitlab, monkeypatch, exception_class, match_msg):
-    from utilities.vcs.gitlab_functions import add_award_to_note_gitlab, _get_gitlab_client
+    from utilities.vcs.gitlab_functions import (_get_gitlab_client,
+                                                add_award_to_note_gitlab)
     _get_gitlab_client.cache_clear()
     
     mock_gitlab.instance.projects.project.mergerequests.mr.notes = MockNotesWithAwards()
@@ -447,7 +451,8 @@ def test_add_award_to_note_gitlab_failures(patched_config_gitlab, mock_gitlab, m
 
 
 def test_check_files_exist_in_repo_gitlab_all_exist(patched_config_gitlab, mock_gitlab):
-    from utilities.vcs.gitlab_functions import check_files_exist_in_repo_gitlab, _get_gitlab_client
+    from utilities.vcs.gitlab_functions import (
+        _get_gitlab_client, check_files_exist_in_repo_gitlab)
     _get_gitlab_client.cache_clear()
 
     project = mock_gitlab.instance.projects.project
@@ -474,7 +479,8 @@ def test_check_files_exist_in_repo_gitlab_all_exist(patched_config_gitlab, mock_
 
 
 def test_check_files_exist_in_repo_gitlab_missing_file_returns_false(patched_config_gitlab, mock_gitlab):
-    from utilities.vcs.gitlab_functions import check_files_exist_in_repo_gitlab, _get_gitlab_client
+    from utilities.vcs.gitlab_functions import (
+        _get_gitlab_client, check_files_exist_in_repo_gitlab)
     _get_gitlab_client.cache_clear()
 
     project = mock_gitlab.instance.projects.project
@@ -497,7 +503,8 @@ def test_check_files_exist_in_repo_gitlab_missing_file_returns_false(patched_con
 
 
 def test_check_files_exist_in_repo_gitlab_missing_directory_returns_false(patched_config_gitlab, mock_gitlab):
-    from utilities.vcs.gitlab_functions import check_files_exist_in_repo_gitlab, _get_gitlab_client
+    from utilities.vcs.gitlab_functions import (
+        _get_gitlab_client, check_files_exist_in_repo_gitlab)
     _get_gitlab_client.cache_clear()
 
     project = mock_gitlab.instance.projects.project
@@ -528,9 +535,7 @@ def test_check_files_exist_in_repo_gitlab_failures(
         patched_config_gitlab, mock_gitlab, monkeypatch, exception_class, match_msg, failure_stage
 ):
     from utilities.vcs.gitlab_functions import (
-        _get_gitlab_client,
-        check_files_exist_in_repo_gitlab,
-    )
+        _get_gitlab_client, check_files_exist_in_repo_gitlab)
     _get_gitlab_client.cache_clear()
 
     event = {
@@ -562,7 +567,8 @@ def test_check_files_exist_in_repo_gitlab_failures(
 
 
 def test_commit_files_to_branch_gitlab_success(patched_config_gitlab, mock_gitlab):
-    from utilities.vcs.gitlab_functions import commit_files_to_branch_gitlab, _get_gitlab_client
+    from utilities.vcs.gitlab_functions import (_get_gitlab_client,
+                                                commit_files_to_branch_gitlab)
     _get_gitlab_client.cache_clear()
 
     event = {
@@ -590,7 +596,8 @@ def test_commit_files_to_branch_gitlab_success(patched_config_gitlab, mock_gitla
 
 
 def test_commit_files_to_branch_gitlab_no_actions_returns_empty_dict(patched_config_gitlab, mock_gitlab):
-    from utilities.vcs.gitlab_functions import commit_files_to_branch_gitlab, _get_gitlab_client
+    from utilities.vcs.gitlab_functions import (_get_gitlab_client,
+                                                commit_files_to_branch_gitlab)
     _get_gitlab_client.cache_clear()
 
     event = {
@@ -615,7 +622,8 @@ def test_commit_files_to_branch_gitlab_no_actions_returns_empty_dict(patched_con
 def test_commit_files_to_branch_gitlab_failures(
         patched_config_gitlab, mock_gitlab, monkeypatch, exception_class, match_msg, failure_at
 ):
-    from utilities.vcs.gitlab_functions import commit_files_to_branch_gitlab, _get_gitlab_client
+    from utilities.vcs.gitlab_functions import (_get_gitlab_client,
+                                                commit_files_to_branch_gitlab)
     _get_gitlab_client.cache_clear()
 
     if exception_class in (gitlab.GitlabAuthenticationError, gitlab.GitlabGetError, gitlab.GitlabCreateError):
@@ -651,7 +659,8 @@ def test_commit_files_to_branch_gitlab_failures(
 
 
 def test_get_all_tf_files_from_paths_list_gitlab_success(patched_config_gitlab, mock_gitlab):
-    from utilities.vcs.gitlab_functions import _get_gitlab_client, get_all_tf_files_from_paths_list_gitlab
+    from utilities.vcs.gitlab_functions import (
+        _get_gitlab_client, get_all_tf_files_from_paths_list_gitlab)
     _get_gitlab_client.cache_clear()
 
     project = mock_gitlab.instance.projects.project
@@ -687,7 +696,8 @@ def test_get_all_tf_files_from_paths_list_gitlab_success(patched_config_gitlab, 
 
 
 def test_get_all_tf_files_from_paths_list_gitlab_no_tf_files(patched_config_gitlab, mock_gitlab):
-    from utilities.vcs.gitlab_functions import _get_gitlab_client, get_all_tf_files_from_paths_list_gitlab
+    from utilities.vcs.gitlab_functions import (
+        _get_gitlab_client, get_all_tf_files_from_paths_list_gitlab)
     _get_gitlab_client.cache_clear()
 
     project = mock_gitlab.instance.projects.project

--- a/terraform/modules/lambdas/functions/utilities/vcs/github_functions.py
+++ b/terraform/modules/lambdas/functions/utilities/vcs/github_functions.py
@@ -15,12 +15,14 @@ from utilities.messages import HELP_MESSAGE
 
 @lru_cache(maxsize=2)
 def _get_github_client(vcs_api_token: str) -> Github:
-    """
-    Fetches the GitHub client with a caching mechanism and verifies the session token.
+    """Fetches the GitHub client with a caching mechanism and verifies the session token.
 
     This function creates and caches a GitHub client by token for accessing the
     GitHub API. It performs a lightweight health check to ensure the token and
     session are valid.
+
+    Args:
+        vcs_api_token (str): The GitHub API token used for authentication.
 
     Returns:
         Github: An authenticated client for accessing GitHub API.
@@ -50,7 +52,22 @@ def _get_github_client(vcs_api_token: str) -> Github:
 
 def _get_pull_request(repo_id_or_name: int | str, pull_number: int,
                       operation: str) -> Any:
-    """Get a GitHub pull request."""
+    """Get a GitHub pull request.
+
+    Args:
+        repo_id_or_name (int | str): GitHub repository ID or full name.
+        pull_number (int): Pull request number.
+        operation (str): Operation name used in unexpected error messages.
+
+    Returns:
+        Any: The requested GitHub pull request.
+
+    Raises:
+        BadCredentialsException: If authentication fails.
+        UnknownObjectException: If the repository or pull request is not found.
+        GithubException: For other GitHub API errors.
+        Exception: For unexpected errors while retrieving the pull request.
+    """
     try:
         gh = _get_github_client(config.vcs_api_token)
         repo = gh.get_repo(repo_id_or_name)
@@ -71,17 +88,32 @@ def _get_pull_request(repo_id_or_name: int | str, pull_number: int,
 
 
 def get_pr_source_branch_name(repo_id_or_name: int | str, pull_number: int) -> str:
-    """Get the source branch name of a GitHub pull request."""
+    """Get the source branch name of a GitHub pull request.
+
+    Args:
+        repo_id_or_name (int | str): GitHub repository ID or full name.
+        pull_number (int): Pull request number.
+
+    Returns:
+        str: The source branch name of the pull request.
+    """
     return _get_pull_request(
         repo_id_or_name, pull_number, "PR source branch"
     ).head.ref
 
 
 def add_reaction_to_pr_comment_github(event: dict[str, Any], reaction: str, ):
-    """Add a reaction emoji to a GitHub pull request conversation comment (IssueComment).
+    """Add a reaction emoji to a GitHub pull request conversation comment
+    (IssueComment).
 
     Args:
-        event (Dict[str, Any]): Event metadata containing repo and PR info.
+        event (dict[str, Any]): Event metadata containing repository, pull request, and
+            comment information.
+            Mandatory keys include:
+            - 'metadata':
+                - 'repo_id_or_name' (int | str): The GitHub repository ID or full name.
+                - 'merge_or_pull_req_id' (int): The pull request number.
+                - 'comment_id' (int): The issue comment ID.
         reaction (str): Normalized GitHub reaction value (see VALID_GITHUB_REACTIONS).
 
     Returns:
@@ -91,7 +123,8 @@ def add_reaction_to_pr_comment_github(event: dict[str, Any], reaction: str, ):
         BadCredentialsException: If authentication fails.
         UnknownObjectException: If repository, PR, or comment is not found.
         GithubException: For other GitHub API errors.
-        ValueError: If the reaction is invalid, or the comment does not belong to the PR.
+        ValueError: If the reaction is invalid, or the comment does not belong to
+            the PR.
     """
 
     try:
@@ -124,7 +157,12 @@ def post_pr_comment_github(event: dict[str, Any], comment_text: str):
     """Post a new comment to a GitHub pull request.
 
     Args:
-        event (Dict[str, Any]): Event metadata containing repo and PR info.
+        event (dict[str, Any]): Event metadata containing repository and pull request
+            information.
+            Mandatory keys include:
+            - 'metadata':
+                - 'repo_id_or_name' (int | str): The GitHub repository ID or full name.
+                - 'merge_or_pull_req_id' (int): The pull request number.
         comment_text (str): Comment body text.
 
     Returns:
@@ -134,7 +172,8 @@ def post_pr_comment_github(event: dict[str, Any], comment_text: str):
         BadCredentialsException: If authentication fails.
         UnknownObjectException: If repository, PR, or comment is not found.
         GithubException: For other GitHub API errors.
-        ValueError: If the reaction is invalid, or the comment does not belong to the PR.
+        ValueError: If the reaction is invalid, or the comment does not belong to
+            the PR.
     """
 
     try:
@@ -162,7 +201,18 @@ def post_pr_comment_github(event: dict[str, Any], comment_text: str):
 
 
 def post_help_message_github(event: dict[str, Any]):
-    """Post a help message on a GitHub pull request."""
+    """Post a help message on a GitHub pull request.
+
+    Args:
+        event (dict[str, Any]): Event metadata identifying the pull request.
+            Mandatory keys include:
+            - 'metadata':
+                - 'repo_id_or_name' (int | str): The GitHub repository ID or full name.
+                - 'merge_or_pull_req_id' (int): The pull request number.
+
+    Returns:
+        Any: The created IssueComment object.
+    """
     return post_pr_comment_github(event, HELP_MESSAGE.format(spec_provider='GitHub PR comments'))
 
 
@@ -172,7 +222,12 @@ def check_files_exist_in_repo_github(event: dict[str, Any],
     """Check that all given files exist in a GitHub repository on a specific branch.
 
     Args:
-        event (Dict[str, Any]): Event metadata containing repo and PR info.
+        event (dict[str, Any]): Event metadata containing repository and pull request
+            information.
+            Mandatory keys include:
+            - 'metadata':
+                - 'repo_id_or_name' (int | str): The GitHub repository ID or full name.
+                - 'merge_or_pull_req_id' (int): The pull request number.
         file_paths (list[str]): Paths to files relative to the repository root.
 
     Returns:
@@ -229,16 +284,21 @@ def check_files_exist_in_repo_github(event: dict[str, Any],
 
 def commit_files_to_branch_github(event: dict[str, Any], file_paths_with_content: list[tuple[str, str]],
                                   commit_message: str):
-    """
-    Commits files with specified content to a branch in a GitHub repository.
+    """Commits files with specified content to a branch in a GitHub repository.
 
     Args:
-        event (Dict[str, Any]): The event data dictionary containing metadata about the repository,
-            such as 'repo_id_or_name' (repository identifier) and 'merge_or_pull_req_id'
-            (the pull/merge request ID).
-        file_paths_with_content (list[tuple[str, str]]): A list of tuples representing file paths
-            and their corresponding content to be committed.
+        event (dict[str, Any]): The event data dictionary containing metadata about the
+            repository.
+            Mandatory keys include:
+            - 'metadata':
+                - 'repo_id_or_name' (int | str): The GitHub repository ID or full name.
+                - 'merge_or_pull_req_id' (int): The pull request number.
+        file_paths_with_content (list[tuple[str, str]]): A list of tuples representing
+            file paths and their corresponding content to be committed.
         commit_message (str): The commit message to include with the changes.
+
+    Returns:
+        None: This function updates the branch and does not return a value.
 
     Raises:
         BadCredentialsException: If there is an authentication failure with GitHub.
@@ -299,7 +359,15 @@ def commit_files_to_branch_github(event: dict[str, Any], file_paths_with_content
 
 
 def get_last_commit_sha_github(repo_id_or_name: int | str, pull_number: int) -> str:
-    """Get the last commit SHA for a GitHub pull request."""
+    """Get the last commit SHA for a GitHub pull request.
+
+    Args:
+        repo_id_or_name (int | str): GitHub repository ID or full name.
+        pull_number (int): Pull request number.
+
+    Returns:
+        str: The SHA of the latest commit on the pull request's source branch.
+    """
     return _get_pull_request(repo_id_or_name, pull_number, "PR head SHA").head.sha
 
 
@@ -307,6 +375,23 @@ def get_all_tf_files_from_paths_list_github(
         event: dict[str, Any],
         paths_list: list[str]
 ) -> list[tuple[str, str]]:
+    """Fetch all Terraform (.tf) files from the specified paths in GitHub.
+
+    Args:
+        event (dict[str, Any]): A dictionary containing metadata about the GitHub
+            repository.
+            Mandatory keys include:
+            - 'metadata':
+                - 'repo_id_or_name' (int | str): The GitHub repository ID or full name.
+                - 'source_branch' (str): The name of the repository branch to fetch
+                    files from.
+        paths_list (list[str]): A list of directory paths within the GitHub repository
+            from which to retrieve Terraform files.
+
+    Returns:
+        list[tuple[str, str]]: A list where each element is a tuple containing the
+            Terraform file path and its decoded UTF-8 content.
+    """
     repo_identifier = event['metadata']['repo_id_or_name']
     branch = event['metadata']['source_branch']
     gh = _get_github_client(config.vcs_api_token)

--- a/terraform/modules/lambdas/functions/utilities/vcs/github_functions.py
+++ b/terraform/modules/lambdas/functions/utilities/vcs/github_functions.py
@@ -45,27 +45,13 @@ def _get_github_client(vcs_api_token: str) -> Github:
     return client  # gets cached only if everything above succeeds
 
 
-def get_pr_source_branch_name(repo_id_or_name: Union[int, str], pull_number: int) -> str:
-    """Get the source branch name of a GitHub pull request.
-
-    Args:
-        repo_id_or_name (Union[int, str]): The repository ID or "owner/name" string.
-        pull_number (int): Pull request number.
-
-    Returns:
-        str: Name of the source branch.
-
-    Raises:
-        BadCredentialsException: If authentication fails.
-        UnknownObjectException: If repository or PR is not found.
-        GithubException: For other GitHub API errors.
-    """
-
+def _get_pull_request(repo_id_or_name: Union[int, str], pull_number: int,
+                      operation: str) -> Any:
+    """Get a GitHub pull request."""
     try:
         gh = _get_github_client(config.vcs_api_token)
         repo = gh.get_repo(repo_id_or_name)
-        pr = repo.get_pull(pull_number)
-        return pr.head.ref
+        return repo.get_pull(pull_number)
 
     except BadCredentialsException as e:
         logger.error(f"GitHub authentication error: {e}.")
@@ -77,8 +63,15 @@ def get_pr_source_branch_name(repo_id_or_name: Union[int, str], pull_number: int
         logger.error(f"GitHub API error: {e}.")
         raise
     except Exception as e:
-        logger.error(f"Unexpected error getting PR source branch: {e}.")
+        logger.error(f"Unexpected error getting {operation}: {e}.")
         raise
+
+
+def get_pr_source_branch_name(repo_id_or_name: Union[int, str], pull_number: int) -> str:
+    """Get the source branch name of a GitHub pull request."""
+    return _get_pull_request(
+        repo_id_or_name, pull_number, "PR source branch"
+    ).head.ref
 
 
 def add_reaction_to_pr_comment_github(event: Dict[str, Any], reaction: str, ):
@@ -302,27 +295,8 @@ def commit_files_to_branch_github(event: Dict[str, Any], file_paths_with_content
 
 
 def get_last_commit_sha_github(repo_id_or_name: Union[int, str], pull_number: int) -> str:
-    """Get the last commit SHA for a GitHub pull request.
-
-    """
-    try:
-        gh = _get_github_client(config.vcs_api_token)
-        repo = gh.get_repo(repo_id_or_name)
-        pr = repo.get_pull(pull_number)
-        return pr.head.sha
-
-    except BadCredentialsException as e:
-        logger.error(f"GitHub authentication error: {e}.")
-        raise
-    except UnknownObjectException as e:
-        logger.error(f"GitHub object not found: {e}.")
-        raise
-    except GithubException as e:
-        logger.error(f"GitHub API error: {e}.")
-        raise
-    except Exception as e:
-        logger.error(f"Unexpected error getting PR head SHA: {e}.")
-        raise
+    """Get the last commit SHA for a GitHub pull request."""
+    return _get_pull_request(repo_id_or_name, pull_number, "PR head SHA").head.sha
 
 
 def get_all_tf_files_from_paths_list_github(
@@ -341,6 +315,9 @@ def get_all_tf_files_from_paths_list_github(
         except GithubException as exc:
             logger.warning(f"Skipping {target_dir}: {exc}")
             continue
+
+        if not isinstance(items, list):
+            items = [items]
 
         for item in items:
             if item.type == "file" and item.path.endswith(".tf"):

--- a/terraform/modules/lambdas/functions/utilities/vcs/github_functions.py
+++ b/terraform/modules/lambdas/functions/utilities/vcs/github_functions.py
@@ -93,10 +93,10 @@ def add_reaction_to_pr_comment_github(event: Dict[str, Any], reaction: str, ):
 
     try:
         gh = _get_github_client(config.vcs_api_token)
-        repo = gh.get_repo(event.get('metadata').get('repo_id_or_name'))
+        repo = gh.get_repo(event['metadata']['repo_id_or_name'])
         # Ensure PR exists (will raise if not)
-        pr = repo.get_pull(event.get('metadata').get('merge_or_pull_req_id'))
-        issue_comment = pr.get_issue_comment(event.get('metadata').get('comment_id'))
+        pr = repo.get_pull(event['metadata']['merge_or_pull_req_id'])
+        issue_comment = pr.get_issue_comment(event['metadata']['comment_id'])
 
         issue_comment.create_reaction(reaction)
         # get all info about comment
@@ -136,9 +136,9 @@ def post_pr_comment_github(event: Dict[str, Any], comment_text: str):
 
     try:
         gh = _get_github_client(config.vcs_api_token)
-        repo = gh.get_repo(event.get('metadata').get('repo_id_or_name'))
+        repo = gh.get_repo(event['metadata']['repo_id_or_name'])
         # Ensure PR exists (will raise if not)
-        pr = repo.get_pull(event.get('metadata').get('merge_or_pull_req_id'))
+        pr = repo.get_pull(event['metadata']['merge_or_pull_req_id'])
 
         issue_comment = pr.create_issue_comment(body=f"{comment_text.strip()}")
 
@@ -181,8 +181,8 @@ def check_files_exist_in_repo_github(event: Dict[str, Any],
         GithubException: For other GitHub API errors.
     """
     try:
-        repo_id_or_name = event.get('metadata').get('repo_id_or_name')
-        merge_or_pull_req_id = event.get('metadata').get('merge_or_pull_req_id')
+        repo_id_or_name = event['metadata']['repo_id_or_name']
+        merge_or_pull_req_id = event['metadata']['merge_or_pull_req_id']
         # Use the source branch of the PR as the default
         branch = get_pr_source_branch_name(repo_id_or_name, merge_or_pull_req_id)
         gh = _get_github_client(config.vcs_api_token)
@@ -227,26 +227,28 @@ def check_files_exist_in_repo_github(event: Dict[str, Any],
 
 def commit_files_to_branch_github(event: Dict[str, Any], file_paths_with_content: list[tuple[str, str]],
                                   commit_message: str):
-    """Commit multiple existing files to a GitHub repository branch in a single commit.
+    """
+    Commits files with specified content to a branch in a GitHub repository.
 
     Args:
-        event (Dict[str, Any]): Event metadata containing repo and PR info.
-        file_paths (list[str]): List of file paths to commit.
-        commit_message (str): Commit message for all files.
-
-    Returns:
-        Any: The commit object created.
+        event (Dict[str, Any]): The event data dictionary containing metadata about the repository,
+            such as 'repo_id_or_name' (repository identifier) and 'merge_or_pull_req_id'
+            (the pull/merge request ID).
+        file_paths_with_content (list[tuple[str, str]]): A list of tuples representing file paths
+            and their corresponding content to be committed.
+        commit_message (str): The commit message to include with the changes.
 
     Raises:
-        BadCredentialsException: If authentication fails.
-        UnknownObjectException: If repository or branch is not found.
-        GithubException: For other GitHub API errors.
+        BadCredentialsException: If there is an authentication failure with GitHub.
+        UnknownObjectException: If a specified repository, commit, or object is not found.
+        GithubException: For other errors related to the GitHub API.
+        Exception: For unexpected errors during the process.
     """
     try:
         gh = _get_github_client(config.vcs_api_token)
-        repo = gh.get_repo(event.get('metadata').get('repo_id_or_name'))
-        merge_or_pull_req_id = event.get('metadata').get('merge_or_pull_req_id')
-        branch = get_pr_source_branch_name(event.get('metadata').get('repo_id_or_name'), merge_or_pull_req_id)
+        repo = gh.get_repo(event['metadata']['repo_id_or_name'])
+        merge_or_pull_req_id = event['metadata']['merge_or_pull_req_id']
+        branch = get_pr_source_branch_name(event['metadata']['repo_id_or_name'], merge_or_pull_req_id)
 
         # Get reference and latest commit
         ref = repo.get_git_ref(f"heads/{branch}")
@@ -303,8 +305,8 @@ def get_all_tf_files_from_paths_list_github(
         event: Dict[str, Any],
         paths_list: List[str]
 ) -> List[tuple[str, str]]:
-    repo_identifier = event.get('metadata', {}).get('repo_id_or_name')
-    branch = event.get('metadata', {}).get('source_branch')
+    repo_identifier = event['metadata']['repo_id_or_name']
+    branch = event['metadata']['source_branch']
     gh = _get_github_client(config.vcs_api_token)
     repo = gh.get_repo(repo_identifier)
 

--- a/terraform/modules/lambdas/functions/utilities/vcs/github_functions.py
+++ b/terraform/modules/lambdas/functions/utilities/vcs/github_functions.py
@@ -87,21 +87,6 @@ def _get_pull_request(repo_id_or_name: int | str, pull_number: int,
         raise
 
 
-def get_pr_source_branch_name(repo_id_or_name: int | str, pull_number: int) -> str:
-    """Get the source branch name of a GitHub pull request.
-
-    Args:
-        repo_id_or_name (int | str): GitHub repository ID or full name.
-        pull_number (int): Pull request number.
-
-    Returns:
-        str: The source branch name of the pull request.
-    """
-    return _get_pull_request(
-        repo_id_or_name, pull_number, "PR source branch"
-    ).head.ref
-
-
 def add_reaction_to_pr_comment_github(event: dict[str, Any], reaction: str, ):
     """Add a reaction emoji to a GitHub pull request conversation comment
     (IssueComment).

--- a/terraform/modules/lambdas/functions/utilities/vcs/github_functions.py
+++ b/terraform/modules/lambdas/functions/utilities/vcs/github_functions.py
@@ -183,10 +183,9 @@ def check_files_exist_in_repo_github(event: Dict[str, Any],
     try:
         repo_id_or_name = event['metadata']['repo_id_or_name']
         merge_or_pull_req_id = event['metadata']['merge_or_pull_req_id']
-        # Use the source branch of the PR as the default
-        branch = get_pr_source_branch_name(repo_id_or_name, merge_or_pull_req_id)
         gh = _get_github_client(config.vcs_api_token)
         repo = gh.get_repo(repo_id_or_name)
+        branch = repo.get_pull(merge_or_pull_req_id).head.ref
         logger.debug(
             f"Checking existence of {len(file_paths)} file(s) in repo '{repo_id_or_name}' "
             f"on branch '{branch}'."
@@ -248,7 +247,7 @@ def commit_files_to_branch_github(event: Dict[str, Any], file_paths_with_content
         gh = _get_github_client(config.vcs_api_token)
         repo = gh.get_repo(event['metadata']['repo_id_or_name'])
         merge_or_pull_req_id = event['metadata']['merge_or_pull_req_id']
-        branch = get_pr_source_branch_name(event['metadata']['repo_id_or_name'], merge_or_pull_req_id)
+        branch = repo.get_pull(merge_or_pull_req_id).head.ref
 
         # Get reference and latest commit
         ref = repo.get_git_ref(f"heads/{branch}")

--- a/terraform/modules/lambdas/functions/utilities/vcs/github_functions.py
+++ b/terraform/modules/lambdas/functions/utilities/vcs/github_functions.py
@@ -1,9 +1,12 @@
 from functools import lru_cache
-from typing import Any, Dict, List, Union
+from typing import Any
 
 from github import Auth, Github, InputGitTreeElement
-from github.GithubException import (BadCredentialsException, GithubException,
-                                    UnknownObjectException)
+from github.GithubException import (
+    BadCredentialsException,
+    GithubException,
+    UnknownObjectException,
+)
 
 from config import config
 from utilities.logger import logger
@@ -45,7 +48,7 @@ def _get_github_client(vcs_api_token: str) -> Github:
     return client  # gets cached only if everything above succeeds
 
 
-def _get_pull_request(repo_id_or_name: Union[int, str], pull_number: int,
+def _get_pull_request(repo_id_or_name: int | str, pull_number: int,
                       operation: str) -> Any:
     """Get a GitHub pull request."""
     try:
@@ -67,14 +70,14 @@ def _get_pull_request(repo_id_or_name: Union[int, str], pull_number: int,
         raise
 
 
-def get_pr_source_branch_name(repo_id_or_name: Union[int, str], pull_number: int) -> str:
+def get_pr_source_branch_name(repo_id_or_name: int | str, pull_number: int) -> str:
     """Get the source branch name of a GitHub pull request."""
     return _get_pull_request(
         repo_id_or_name, pull_number, "PR source branch"
     ).head.ref
 
 
-def add_reaction_to_pr_comment_github(event: Dict[str, Any], reaction: str, ):
+def add_reaction_to_pr_comment_github(event: dict[str, Any], reaction: str, ):
     """Add a reaction emoji to a GitHub pull request conversation comment (IssueComment).
 
     Args:
@@ -117,7 +120,7 @@ def add_reaction_to_pr_comment_github(event: Dict[str, Any], reaction: str, ):
         raise
 
 
-def post_pr_comment_github(event: Dict[str, Any], comment_text: str):
+def post_pr_comment_github(event: dict[str, Any], comment_text: str):
     """Post a new comment to a GitHub pull request.
 
     Args:
@@ -158,12 +161,12 @@ def post_pr_comment_github(event: Dict[str, Any], comment_text: str):
         raise
 
 
-def post_help_message_github(event: Dict[str, Any]):
+def post_help_message_github(event: dict[str, Any]):
     """Post a help message on a GitHub pull request."""
     return post_pr_comment_github(event, HELP_MESSAGE.format(spec_provider='GitHub PR comments'))
 
 
-def check_files_exist_in_repo_github(event: Dict[str, Any],
+def check_files_exist_in_repo_github(event: dict[str, Any],
                                      file_paths: list[str],
                                      ) -> bool:
     """Check that all given files exist in a GitHub repository on a specific branch.
@@ -224,7 +227,7 @@ def check_files_exist_in_repo_github(event: Dict[str, Any],
         raise
 
 
-def commit_files_to_branch_github(event: Dict[str, Any], file_paths_with_content: list[tuple[str, str]],
+def commit_files_to_branch_github(event: dict[str, Any], file_paths_with_content: list[tuple[str, str]],
                                   commit_message: str):
     """
     Commits files with specified content to a branch in a GitHub repository.
@@ -295,21 +298,21 @@ def commit_files_to_branch_github(event: Dict[str, Any], file_paths_with_content
         raise
 
 
-def get_last_commit_sha_github(repo_id_or_name: Union[int, str], pull_number: int) -> str:
+def get_last_commit_sha_github(repo_id_or_name: int | str, pull_number: int) -> str:
     """Get the last commit SHA for a GitHub pull request."""
     return _get_pull_request(repo_id_or_name, pull_number, "PR head SHA").head.sha
 
 
 def get_all_tf_files_from_paths_list_github(
-        event: Dict[str, Any],
-        paths_list: List[str]
-) -> List[tuple[str, str]]:
+        event: dict[str, Any],
+        paths_list: list[str]
+) -> list[tuple[str, str]]:
     repo_identifier = event['metadata']['repo_id_or_name']
     branch = event['metadata']['source_branch']
     gh = _get_github_client(config.vcs_api_token)
     repo = gh.get_repo(repo_identifier)
 
-    tf_files: List[tuple[str, str]] = []
+    tf_files: list[tuple[str, str]] = []
     for target_dir in paths_list:
         try:
             items = repo.get_contents(target_dir, ref=branch)

--- a/terraform/modules/lambdas/functions/utilities/vcs/gitlab_functions.py
+++ b/terraform/modules/lambdas/functions/utilities/vcs/gitlab_functions.py
@@ -160,10 +160,9 @@ def check_files_exist_in_repo_gitlab(
         project_id_or_path = event.get('metadata').get('repo_id_or_name')
         merge_request_id = event.get('metadata').get('merge_or_pull_req_id')
 
-        branch = get_mr_source_branch_name(project_id_or_path, merge_request_id)
-
         gl = _get_gitlab_client(config.vcs_api_token)
         project = gl.projects.get(project_id_or_path)
+        branch = project.mergerequests.get(merge_request_id).source_branch
 
         logger.debug(
             f"Batch-checking {len(file_paths)} file(s) in project "

--- a/terraform/modules/lambdas/functions/utilities/vcs/gitlab_functions.py
+++ b/terraform/modules/lambdas/functions/utilities/vcs/gitlab_functions.py
@@ -3,8 +3,7 @@ from functools import lru_cache
 from pathlib import PurePosixPath
 from typing import Any
 
-import gitlab
-from gitlab import GitlabAuthenticationError, GitlabGetError
+from gitlab import Gitlab, GitlabAuthenticationError, GitlabCreateError, GitlabGetError
 
 from config import config
 from utilities.logger import logger
@@ -12,10 +11,26 @@ from utilities.messages import HELP_MESSAGE
 
 
 @lru_cache(maxsize=2)
-def _get_gitlab_client(vcs_api_token: str) -> gitlab.Gitlab:
-    """Return an authenticated and verified GitLab client instance."""
+def _get_gitlab_client(vcs_api_token: str) -> Gitlab:
+    """Gets a cached GitLab client instance configured with the provided API token.
 
-    client = gitlab.Gitlab(
+    This function creates and authenticates a GitLab client using the provided API token.
+    It also performs a lightweight health check by verifying the client version to ensure
+    the session is valid before caching the client instance. If any authentication or
+    verification step fails, an exception will be raised, and the client object will
+    not be cached.
+
+    Args:
+        vcs_api_token (str): The GitLab API token used for authentication.
+
+    Returns:
+        Gitlab: An authenticated GitLab client instance.
+
+    Raises:
+        Exception: If the GitLab client authentication or version verification fails.
+    """
+
+    client = Gitlab(
         url=config.vcs_api_endpoint,
         private_token=vcs_api_token,
     )
@@ -38,18 +53,27 @@ def get_mr_source_branch_name(
         project_id_or_path: str,
         merge_request_id: int,
 ) -> str:
-    """Get the source branch name of a GitLab Merge Request.
+    """Fetches the source branch name of a specific merge request within a given project.
+
+    This function connects to a GitLab instance using a pre-configured token, retrieves
+    the project and merge request specified by their IDs, and extracts the name of the
+    source branch for the merge request. It handles various exceptions that might
+    occur during the API interaction, such as authentication or API errors.
 
     Args:
-        project_id_or_path (str): GitLab project ID or 'namespace/project'.
-        merge_request_id (int): Merge Request IID (not global ID).
+        project_id_or_path (str): Identifier or path of the GitLab project that contains
+            the merge request.
+        merge_request_id (int): Unique identifier of the merge request in the specified
+            project.
 
     Returns:
-        str: Source branch name.
+        str: Name of the source branch of the merge request.
 
     Raises:
-        GitlabAuthenticationError: If authentication fails.
-        GitlabGetError: If a project or MR is not found.
+        GitlabAuthenticationError: If authentication with the GitLab API fails.
+        GitlabGetError: If the merge request or project information cannot be retrieved
+            from the GitLab API.
+        Exception: If any other unexpected error occurs during the process.
     """
     try:
         gl = _get_gitlab_client(config.vcs_api_token)
@@ -88,10 +112,34 @@ def add_award_to_note_gitlab(
         event: dict[str, Any],
         reaction: str
 ) -> dict[str, Any]:
-    """Add an award emoji to a GitLab merge request note.
+    """Adds an award emoji reaction to a specific note on a GitLab merge request.
 
+    This function interacts with the GitLab API to add a specific reaction
+    (award emoji) to a comment (note) on a merge request. It requires valid
+    configuration and authentication tokens to function properly. The GitLab
+    project, merge request, and note are identified using the metadata from
+    the input event.
+
+    Args:
+        event (dict[str, Any]): A dictionary containing metadata necessary to perform
+            the action.
+            Expected keys include:
+            - 'metadata':
+                - 'repo_id_or_name' (str): The GitLab project ID or path.
+                - 'merge_or_pull_req_id' (int): The merge request ID.
+                - 'comment_id' (int): The note ID.
+        reaction (str): The name of the award emoji reaction to be added to the note.
+
+    Returns:
+        dict[str, Any]: A dictionary containing the attributes of the created award
+            emoji.
+
+    Raises:
+        GitlabAuthenticationError: If there is an issue with GitLab authentication.
+        GitlabGetError: If there is an error retrieving GitLab project, merge request,
+            or note details.
+        Exception: If an unexpected error occurs during the process.
     """
-
     try:
         gl = _get_gitlab_client(config.vcs_api_token)
 
@@ -103,10 +151,10 @@ def add_award_to_note_gitlab(
         logger.debug(f"Added GitLab award emoji: {award.attributes}.")
         return award.attributes
 
-    except gitlab.exceptions.GitlabAuthenticationError as e:
+    except GitlabAuthenticationError as e:
         logger.error(f"GitLab authentication error: {e}.")
         raise
-    except gitlab.exceptions.GitlabGetError as e:
+    except GitlabGetError as e:
         logger.error(f"GitLab get error: {e}.")
         raise
     except Exception as e:
@@ -115,14 +163,32 @@ def add_award_to_note_gitlab(
 
 
 def post_gitlab_comment(event: dict[str, Any], comment_text: str) -> dict[str, Any]:
-    """Post a comment on a GitLab merge request.
+    """Posts a comment on a GitLab merge request.
+
+    This function interacts with the GitLab API to post a comment on a specified
+    GitLab merge request using the provided event details and comment text. It
+    handles authentication and error reporting.
 
     Args:
+        event (dict[str, Any]): A dictionary containing metadata about the GitLab
+            repository and merge request.
+            Mandatory keys include:
+            - 'metadata':
+                - 'repo_id_or_name' (str): The GitLab repository ID or name.
+                - 'merge_or_pull_req_id' (int): The merge request ID.
+        comment_text (str): The text content of the comment to be posted.
 
     Returns:
-        Dict[str, Any]: The JSON response from the GitLab API.
-    """
+        dict[str, Any]: A dictionary containing the attributes of the created
+            comment.
 
+    Raises:
+        GitlabAuthenticationError: If there is an authentication issue with the
+            GitLab API.
+        GitlabGetError: If there is an error retrieving the specified repository
+            or merge request.
+        Exception: For unexpected errors encountered during the operation.
+    """
     try:
         gl = _get_gitlab_client(config.vcs_api_token)
         project = gl.projects.get(event['metadata']['repo_id_or_name'])
@@ -132,10 +198,10 @@ def post_gitlab_comment(event: dict[str, Any], comment_text: str) -> dict[str, A
         logger.debug(f"Posted GitLab merge request comment: {note.attributes}.")
         return note.attributes
 
-    except gitlab.exceptions.GitlabAuthenticationError as e:
+    except GitlabAuthenticationError as e:
         logger.error(f"GitLab authentication error: {e}.")
         raise
-    except gitlab.exceptions.GitlabGetError as e:
+    except GitlabGetError as e:
         logger.error(f"GitLab get error: {e}.")
         raise
     except Exception as e:
@@ -144,11 +210,41 @@ def post_gitlab_comment(event: dict[str, Any], comment_text: str) -> dict[str, A
 
 
 def post_help_message_gitlab(event: dict[str, Any]) -> dict[str, Any]:
-    """Post a help message on a GitLab merge request."""
+    """Posts a help message as a GitLab merge request comment.
+
+    This function generates and posts a help message to a GitLab merge request
+    comment using the provided event data.
+
+    Args:
+        event (dict[str, Any]): A dictionary containing event data relevant to the
+            GitLab merge request. This typically includes information needed
+            for identifying the merge request and generating the comment.
+            Expected keys include:
+            - 'metadata':
+                - 'repo_id_or_name' (str): The GitLab repository ID or name.
+                - 'merge_or_pull_req_id' (int): The merge request ID.
+
+    Returns:
+        dict[str, Any]: A dictionary containing the response from the GitLab API
+            after posting the comment.
+    """
     return post_gitlab_comment(event, HELP_MESSAGE.format(spec_provider='GitLab MR notes'))
 
 
 def _group_file_paths_by_directory(file_paths: list[str]) -> dict[str, set[str]]:
+    """Groups a list of file paths by their parent directories.
+
+    This function takes a list of file paths and organizes them into a dictionary where the
+    keys are directory paths and the values are sets of file names belonging to each directory.
+
+    Args:
+        file_paths (list[str]): A list of file paths as strings to be grouped by their
+            parent directory.
+
+    Returns:
+        dict[str, set[str]]: A dictionary mapping directory paths (keys) to sets of file names
+            (values) belonging to those directories.
+    """
     files_by_dir: dict[str, set[str]] = {}
 
     for path in file_paths:
@@ -166,6 +262,28 @@ def _get_missing_files_from_directory(
         expected_files: set[str],
         branch: str,
 ) -> list[str]:
+    """Identifies missing files from a specified directory in a GitLab repository.
+
+    This function compares a set of expected files with the actual contents of a directory
+    in a GitLab repository. It returns a list of files that are expected but not present in
+    the specified directory.
+
+    Args:
+        project (Any): The GitLab project instance, used to query the repository.
+        dir_path (str): The directory path within the repository to check. If None or
+            an empty string,
+            the root directory will be checked.
+        expected_files (set[str]): A set of file names that are expected to exist in
+            the specified directory.
+        branch (str): The name of the branch in the repository to query the directory contents.
+
+    Returns:
+        list[str]: A list of missing file paths relative to the repository root.
+
+    Raises:
+        GitlabGetError: If a non-404 error occurs while fetching the directory tree
+            from the repository.
+    """
     logger.debug(f"Fetching GitLab repository tree for directory {dir_path or '/'}")
 
     try:
@@ -199,9 +317,34 @@ def check_files_exist_in_repo_gitlab(
         event: dict[str, Any],
         file_paths: list[str],
 ) -> bool:
-    """Batch-check file existence in a GitLab repo using a repository tree.
+    """Checks if the given files exist in a GitLab repository on a specific branch.
 
-    Uses fewer API calls than per-file lookup.
+    This function verifies the existence of a list of files in a specified GitLab
+    repository and branch. It uses the metadata provided in the event dictionary
+    to fetch the repository and branch details. If any file from the list does not
+    exist in the repository, the function logs a warning and returns `False`,
+    otherwise it returns `True`.
+
+    Args:
+        event (dict[str, Any]): A dictionary containing metadata about the repository
+            and branch.
+            Mandatory keys include:
+            - 'metadata':
+                - 'repo_id_or_name' (str): The project identifier or name.
+                - 'merge_or_pull_req_id' (int): The merge request ID.
+        file_paths (list[str]): A list of file paths to check for existence in the
+            repository.
+
+    Returns:
+        bool: `True` if all the files exist on the specified branch in the repository,
+        `False` otherwise.
+
+    Raises:
+        GitlabAuthenticationError: If there is an authentication error with the GitLab
+            client.
+        GitlabGetError: If there is an API-related error while accessing the GitLab
+            repository or merge request.
+        Exception: If any other unexpected error occurs during the operation.
     """
     try:
         project_id_or_path = event['metadata']['repo_id_or_name']
@@ -252,25 +395,34 @@ def commit_files_to_branch_gitlab(
         file_paths_with_content: list[tuple[str, str]],
         commit_message: str,
 ) -> dict[str, Any]:
-    """Commit multiple files to a GitLab merge request source branch in a single commit.
+    """Commits a list of files to a specific branch in a GitLab project.
+
+    The branch used for the commit is the source branch of a merge request specified
+    in the event metadata. Each file in the provided list is updated or created in
+    the commit based on the action specified.
 
     Args:
-        event (Dict[str, Any]): Event metadata containing repo and MR info.
-            Expected keys in event["metadata"]:
-              - "repo_id_or_name": GitLab project ID or path
-              - "merge_or_pull_req_id": Merge request IID
-        file_paths_with_content (list[tuple[str, str]]): List of (path, content) pairs.
-            Paths are relative to the repository root.
-        commit_message (str): Commit message for all files.
+        event (dict[str, Any]): The event contains metadata including the GitLab project ID or name
+            and the merge request ID. These are used to derive the project details and the branch to
+            which the files will be committed.
+            Mandatory keys include:
+            - 'metadata':
+                - 'repo_id_or_name' (str): The GitLab project ID or name.
+                - 'merge_or_pull_req_id' (int): The merge request ID.
+        file_paths_with_content (list[tuple[str, str]]): A list of tuples where each tuple consists of
+            the file path as a string and the file content as a string. These represent the files to
+            update or create in the branch.
+        commit_message (str): The commit message to associate with the commit.
 
     Returns:
-        Dict[str, Any]: The created commit attributes from GitLab.
+        dict[str, Any]: The attributes of the created commit, containing details about the commit, such
+        as its ID, the committed files, and other GitLab metadata.
 
     Raises:
-        gitlab.exceptions.GitlabAuthenticationError: If authentication fails.
-        gitlab.exceptions.GitlabGetError: If the project or MR is not found.
-        gitlab.exceptions.GitlabCreateError: For other GitLab API errors during commit creation.
-        Exception: For unexpected errors.
+        GitlabAuthenticationError: If authentication to the GitLab API fails.
+        GitlabGetError: If there is an error retrieving project or merge request details.
+        GitlabCreateError: If there is an error creating the commit in GitLab.
+        Exception: For any other unexpected errors during the commit process.
     """
     try:
         gl = _get_gitlab_client(config.vcs_api_token)
@@ -320,13 +472,13 @@ def commit_files_to_branch_gitlab(
         )
         return commit.attributes
 
-    except gitlab.exceptions.GitlabAuthenticationError as e:
+    except GitlabAuthenticationError as e:
         logger.error(f"GitLab authentication error while committing files: {e}.")
         raise
-    except gitlab.exceptions.GitlabGetError as e:
+    except GitlabGetError as e:
         logger.error(f"GitLab get error while committing files: {e}.")
         raise
-    except gitlab.exceptions.GitlabCreateError as e:
+    except GitlabCreateError as e:
         logger.error(f"GitLab create error while committing files: {e}.")
         raise
     except Exception as e:
@@ -338,6 +490,28 @@ def get_all_tf_files_from_paths_list_gitlab(
         event: dict[str, Any],
         paths_list: list[str]
 ) -> list[tuple[str, str]]:
+    """Fetches all Terraform (.tf) files from the specified paths in a GitLab repository.
+
+    This function connects to GitLab using a pre-configured API client, retrieves files with the
+    ".tf" extension from the provided list of directory paths, and decodes their contents
+    from base64 to a UTF-8 text string. The result is a list of tuples containing the file path
+    and its content.
+
+    Args:
+        event (dict[str, Any]): A dictionary containing metadata about the GitLab repository.
+            Mandatory keys include:
+            - 'metadata':
+                - 'repo_id_or_name' (str): The ID or name of the GitLab repository.
+                - 'source_branch' (str): The name of the repository branch to fetch files from.
+
+        paths_list (list[str]): A list of directory paths within the GitLab repository from
+            which to retrieve Terraform files.
+
+    Returns:
+        list[tuple[str, str]]: A list where each element is a tuple containing:
+            - str: The file path of the Terraform file within the repository.
+            - str: The decoded content of the Terraform file as a UTF-8 string.
+    """
     gl = _get_gitlab_client(config.vcs_api_token)
     project = gl.projects.get(event['metadata']['repo_id_or_name'])
 

--- a/terraform/modules/lambdas/functions/utilities/vcs/gitlab_functions.py
+++ b/terraform/modules/lambdas/functions/utilities/vcs/gitlab_functions.py
@@ -49,65 +49,6 @@ def _get_gitlab_client(vcs_api_token: str) -> Gitlab:
     return client  # gets cached only if everything above succeeds
 
 
-def get_mr_source_branch_name(
-        project_id_or_path: str,
-        merge_request_id: int,
-) -> str:
-    """Fetches the source branch name of a specific merge request within a given project.
-
-    This function connects to a GitLab instance using a pre-configured token, retrieves
-    the project and merge request specified by their IDs, and extracts the name of the
-    source branch for the merge request. It handles various exceptions that might
-    occur during the API interaction, such as authentication or API errors.
-
-    Args:
-        project_id_or_path (str): Identifier or path of the GitLab project that contains
-            the merge request.
-        merge_request_id (int): Unique identifier of the merge request in the specified
-            project.
-
-    Returns:
-        str: Name of the source branch of the merge request.
-
-    Raises:
-        GitlabAuthenticationError: If authentication with the GitLab API fails.
-        GitlabGetError: If the merge request or project information cannot be retrieved
-            from the GitLab API.
-        Exception: If any other unexpected error occurs during the process.
-    """
-    try:
-        gl = _get_gitlab_client(config.vcs_api_token)
-        project = gl.projects.get(project_id_or_path)
-        mr = project.mergerequests.get(merge_request_id)
-
-        source_branch = mr.source_branch
-
-        logger.debug(
-            f"MR {merge_request_id} source branch: '{source_branch}' "
-            f"(project: '{project_id_or_path}')"
-        )
-
-        return source_branch
-
-    except GitlabAuthenticationError as e:
-        logger.error(f"GitLab authentication error while fetching MR: {e}.")
-        raise
-
-    except GitlabGetError as e:
-        logger.error(
-            f"GitLab API error while fetching MR "
-            f"{merge_request_id} in project '{project_id_or_path}': {e}."
-        )
-        raise
-
-    except Exception as e:
-        logger.error(
-            f"Unexpected error while getting source branch for MR "
-            f"{merge_request_id}: {e}."
-        )
-        raise
-
-
 def add_award_to_note_gitlab(
         event: dict[str, Any],
         reaction: str
@@ -287,10 +228,13 @@ def _get_missing_files_from_directory(
     logger.debug(f"Fetching GitLab repository tree for directory {dir_path or '/'}")
 
     try:
+        # get_all=True is required: without it python-gitlab returns only the first
+        # page, and existing files beyond it would be reported as missing.
         tree = project.repository_tree(
             path=dir_path or None,
             ref=branch,
             recursive=False,
+            get_all=True,
         )
     except GitlabGetError as e:
         if e.response_code != 404:
@@ -519,7 +463,12 @@ def get_all_tf_files_from_paths_list_gitlab(
     tf_files = []
 
     for target_dir in paths_list:
-        items = project.repository_tree(path=target_dir, ref=event['metadata']['source_branch'])
+
+        items = project.repository_tree(
+            path=target_dir,
+            ref=event['metadata']['source_branch'],
+            get_all=True,
+        )
         for item in items:
             if item['type'] == 'blob' and item['name'].endswith('.tf'):
                 logger.info(f"Fetching Terraform file '{item['path']}' from GitLab...")

--- a/terraform/modules/lambdas/functions/utilities/vcs/gitlab_functions.py
+++ b/terraform/modules/lambdas/functions/utilities/vcs/gitlab_functions.py
@@ -1,7 +1,7 @@
 import base64
 from functools import lru_cache
 from pathlib import PurePosixPath
-from typing import Any, Dict, List
+from typing import Any
 
 import gitlab
 from gitlab import GitlabAuthenticationError, GitlabGetError
@@ -85,9 +85,9 @@ def get_mr_source_branch_name(
 
 
 def add_award_to_note_gitlab(
-        event: Dict[str, Any],
+        event: dict[str, Any],
         reaction: str
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Add an award emoji to a GitLab merge request note.
 
     """
@@ -95,9 +95,9 @@ def add_award_to_note_gitlab(
     try:
         gl = _get_gitlab_client(config.vcs_api_token)
 
-        project = gl.projects.get(event.get('metadata').get('repo_id_or_name'))
-        mr = project.mergerequests.get(event.get('metadata').get('merge_or_pull_req_id'))
-        note = mr.notes.get(event.get('metadata').get('comment_id'))
+        project = gl.projects.get(event['metadata']['repo_id_or_name'])
+        mr = project.mergerequests.get(event['metadata']['merge_or_pull_req_id'])
+        note = mr.notes.get(event['metadata']['comment_id'])
         award = note.awardemojis.create({'name': reaction})
 
         logger.debug(f"Added GitLab award emoji: {award.attributes}.")
@@ -114,7 +114,7 @@ def add_award_to_note_gitlab(
         raise
 
 
-def post_gitlab_comment(event: Dict[str, Any], comment_text: str) -> Dict[str, Any]:
+def post_gitlab_comment(event: dict[str, Any], comment_text: str) -> dict[str, Any]:
     """Post a comment on a GitLab merge request.
 
     Args:
@@ -125,8 +125,8 @@ def post_gitlab_comment(event: Dict[str, Any], comment_text: str) -> Dict[str, A
 
     try:
         gl = _get_gitlab_client(config.vcs_api_token)
-        project = gl.projects.get(event.get('metadata').get('repo_id_or_name'))
-        mr = project.mergerequests.get(event.get('metadata').get('merge_or_pull_req_id'))
+        project = gl.projects.get(event['metadata']['repo_id_or_name'])
+        mr = project.mergerequests.get(event['metadata']['merge_or_pull_req_id'])
         note = mr.notes.create({'body': comment_text})
 
         logger.debug(f"Posted GitLab merge request comment: {note.attributes}.")
@@ -143,22 +143,22 @@ def post_gitlab_comment(event: Dict[str, Any], comment_text: str) -> Dict[str, A
         raise
 
 
-def post_help_message_gitlab(event: Dict[str, Any]) -> Dict[str, Any]:
+def post_help_message_gitlab(event: dict[str, Any]) -> dict[str, Any]:
     """Post a help message on a GitLab merge request."""
     return post_gitlab_comment(event, HELP_MESSAGE.format(spec_provider='GitLab MR notes'))
 
 
 def check_files_exist_in_repo_gitlab(
-        event: Dict[str, Any],
-        file_paths: List[str],
+        event: dict[str, Any],
+        file_paths: list[str],
 ) -> bool:
     """Batch-check file existence in a GitLab repo using a repository tree.
 
     Uses fewer API calls than per-file lookup.
     """
     try:
-        project_id_or_path = event.get('metadata').get('repo_id_or_name')
-        merge_request_id = event.get('metadata').get('merge_or_pull_req_id')
+        project_id_or_path = event['metadata']['repo_id_or_name']
+        merge_request_id = event['metadata']['merge_or_pull_req_id']
 
         gl = _get_gitlab_client(config.vcs_api_token)
         project = gl.projects.get(project_id_or_path)
@@ -177,7 +177,7 @@ def check_files_exist_in_repo_gitlab(
             dir_path = str(p.parent) if str(p.parent) != "." else ""
             files_by_dir.setdefault(dir_path, set()).add(p.name)
 
-        missing_files: List[str] = []
+        missing_files: list[str] = []
 
         for dir_path, expected_files in files_by_dir.items():
             logger.debug(f"Fetching GitLab repository tree for directory {dir_path or '/'}")
@@ -191,9 +191,9 @@ def check_files_exist_in_repo_gitlab(
             except GitlabGetError as e:
                 if e.response_code == 404:
                     # Directory itself does not exist
-                    for fname in expected_files:
+                    for file_name in expected_files:
                         missing_files.append(
-                            f"{dir_path}/{fname}" if dir_path else fname
+                            f"{dir_path}/{file_name}" if dir_path else file_name
                         )
                     continue
                 raise
@@ -204,10 +204,10 @@ def check_files_exist_in_repo_gitlab(
                 if item["type"] == "blob"
             }
 
-            for fname in expected_files:
-                if fname not in existing_files:
+            for file_name in expected_files:
+                if file_name not in existing_files:
                     missing_files.append(
-                        f"{dir_path}/{fname}" if dir_path else fname
+                        f"{dir_path}/{file_name}" if dir_path else file_name
                     )
 
         if missing_files:
@@ -231,10 +231,10 @@ def check_files_exist_in_repo_gitlab(
 
 
 def commit_files_to_branch_gitlab(
-        event: Dict[str, Any],
+        event: dict[str, Any],
         file_paths_with_content: list[tuple[str, str]],
         commit_message: str,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Commit multiple files to a GitLab merge request source branch in a single commit.
 
     Args:
@@ -318,21 +318,21 @@ def commit_files_to_branch_gitlab(
 
 
 def get_all_tf_files_from_paths_list_gitlab(
-        event: Dict[str, Any],
-        paths_list: List[str]
-) -> List[tuple[str, str]]:
+        event: dict[str, Any],
+        paths_list: list[str]
+) -> list[tuple[str, str]]:
     gl = _get_gitlab_client(config.vcs_api_token)
-    project = gl.projects.get(event.get('metadata').get('repo_id_or_name'))
+    project = gl.projects.get(event['metadata']['repo_id_or_name'])
 
     # List to hold tuples of (repo_path, file_content_text)
     tf_files = []
 
     for target_dir in paths_list:
-        items = project.repository_tree(path=target_dir, ref=event.get('metadata').get('source_branch'))
+        items = project.repository_tree(path=target_dir, ref=event['metadata']['source_branch'])
         for item in items:
             if item['type'] == 'blob' and item['name'].endswith('.tf'):
                 logger.info(f"Fetching Terraform file '{item['path']}' from GitLab...")
-                file = project.files.get(file_path=item['path'], ref=event.get('metadata').get('source_branch'))
+                file = project.files.get(file_path=item['path'], ref=event['metadata']['source_branch'])
                 # Decode base64 content to text string (assume UTF-8)
                 content_text = base64.b64decode(file.content).decode('utf-8')
                 tf_files.append((item['path'], content_text))

--- a/terraform/modules/lambdas/functions/utilities/vcs/gitlab_functions.py
+++ b/terraform/modules/lambdas/functions/utilities/vcs/gitlab_functions.py
@@ -148,6 +148,53 @@ def post_help_message_gitlab(event: dict[str, Any]) -> dict[str, Any]:
     return post_gitlab_comment(event, HELP_MESSAGE.format(spec_provider='GitLab MR notes'))
 
 
+def _group_file_paths_by_directory(file_paths: list[str]) -> dict[str, set[str]]:
+    files_by_dir: dict[str, set[str]] = {}
+
+    for path in file_paths:
+        posix_path = PurePosixPath(path)
+        parent = str(posix_path.parent)
+        dir_path = parent if parent != "." else ""
+        files_by_dir.setdefault(dir_path, set()).add(posix_path.name)
+
+    return files_by_dir
+
+
+def _get_missing_files_from_directory(
+        project: Any,
+        dir_path: str,
+        expected_files: set[str],
+        branch: str,
+) -> list[str]:
+    logger.debug(f"Fetching GitLab repository tree for directory {dir_path or '/'}")
+
+    try:
+        tree = project.repository_tree(
+            path=dir_path or None,
+            ref=branch,
+            recursive=False,
+        )
+    except GitlabGetError as e:
+        if e.response_code != 404:
+            raise
+        return [
+            f"{dir_path}/{file_name}" if dir_path else file_name
+            for file_name in expected_files
+        ]
+
+    existing_files = {
+        item["name"]
+        for item in tree
+        if item["type"] == "blob"
+    }
+
+    return [
+        f"{dir_path}/{file_name}" if dir_path else file_name
+        for file_name in expected_files
+        if file_name not in existing_files
+    ]
+
+
 def check_files_exist_in_repo_gitlab(
         event: dict[str, Any],
         file_paths: list[str],
@@ -169,46 +216,16 @@ def check_files_exist_in_repo_gitlab(
             f"'{project_id_or_path}' on branch '{branch}'."
         )
 
-        # Group requested files by directory
-        files_by_dir: dict[str, set[str]] = {}
-
-        for path in file_paths:
-            p = PurePosixPath(path)
-            dir_path = str(p.parent) if str(p.parent) != "." else ""
-            files_by_dir.setdefault(dir_path, set()).add(p.name)
-
         missing_files: list[str] = []
-
-        for dir_path, expected_files in files_by_dir.items():
-            logger.debug(f"Fetching GitLab repository tree for directory {dir_path or '/'}")
-
-            try:
-                tree = project.repository_tree(
-                    path=dir_path or None,
-                    ref=branch,
-                    recursive=False,
+        for dir_path, expected_files in _group_file_paths_by_directory(file_paths).items():
+            missing_files.extend(
+                _get_missing_files_from_directory(
+                    project=project,
+                    dir_path=dir_path,
+                    expected_files=expected_files,
+                    branch=branch,
                 )
-            except GitlabGetError as e:
-                if e.response_code == 404:
-                    # Directory itself does not exist
-                    for file_name in expected_files:
-                        missing_files.append(
-                            f"{dir_path}/{file_name}" if dir_path else file_name
-                        )
-                    continue
-                raise
-
-            existing_files = {
-                item["name"]
-                for item in tree
-                if item["type"] == "blob"
-            }
-
-            for file_name in expected_files:
-                if file_name not in existing_files:
-                    missing_files.append(
-                        f"{dir_path}/{file_name}" if dir_path else file_name
-                    )
+            )
 
         if missing_files:
             logger.warning(f"Some requested file(s) are missing from the repository: {missing_files}")


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce? -->
- [ ] New feature (feat)
- [x] Bug fix (fix)
- [ ] Documentation (docs)
- [x] Refactor (refactor)
- [ ] Chore (chore)

## Why we need this PR
GitLab repository-tree requests returned only the first page of results, which could report existing files as missing and omit Terraform files from analysis. GitHub and GitLab operations also fetched the same repository/project more than once when resolving pull or merge request source branches, creating unnecessary API traffic.

## What was done
- Added `get_all=True` to GitLab repository-tree calls when checking file existence and collecting Terraform files, ensuring every page of results is processed.
- Reused the already-fetched GitLab project and GitHub repository when resolving merge request and pull request source branches.
- Removed redundant GitHub and GitLab source-branch helper functions and their duplicate API calls.
- Extracted GitLab file-checking logic into helpers that group files by directory and determine missing files from a repository-tree response.
- Updated GitHub Terraform file retrieval to support both directory listings and a direct single-file response.
- Simplified VCS type annotations, exception imports, and access to required event metadata.
- Expanded utility-function docstrings.
- Updated tests to verify full GitLab tree retrieval and reduced repository/project and pull/merge request fetches.

## How it was tested
- [x] Manually
- [x] Automatically
