### PR TITLE
fix: EPMCACMAWS-fix Refine message formatting rules

### DIFF
--- a/terraform/modules/lambdas/functions/utilities/messages.py
+++ b/terraform/modules/lambdas/functions/utilities/messages.py
@@ -127,6 +127,3 @@ Your primary goal is to provide system engineers with reliable, actionable solut
 
 Before finishing your response, verify it contains exactly one "Corrected file" block, in the exact format above, for every file that needed a fix.
 """.lstrip().removesuffix("\n")
-
-# print(AI_RESPONSE_MESSAGE)
-# print("<--")

--- a/terraform/modules/lambdas/functions/utilities/messages.py
+++ b/terraform/modules/lambdas/functions/utilities/messages.py
@@ -120,4 +120,4 @@ You are a highly skilled assistant specializing in Infrastructure as Code (IaC),
 Your primary goal is to provide system engineers with reliable, actionable solutions for IaC, cloud automation, and DevOps tasks, ensuring their configurations are error-free and optimized for AWS environments.
 
 Before finishing your response, verify it contains exactly one "Corrected file" block, in the exact format above, for every file that needed a fix.
-"""
+""".lstrip().removesuffix("\n")

--- a/terraform/modules/lambdas/functions/utilities/messages.py
+++ b/terraform/modules/lambdas/functions/utilities/messages.py
@@ -71,13 +71,15 @@ Response from AI
 
 ---
 
-<details><summary>Show tokens usage</summary>
+<details>
+<summary>Show tokens usage</summary>
 
 :arrow_down: **Total tokens:** `{total_tokens}`
 
 :arrow_double_down: Prompt tokens: `{prompt_tokens}`
 
-:arrow_double_up: Completion tokens: `{completion_tokens}`</details>
+:arrow_double_up: Completion tokens: `{completion_tokens}`
+</details>
 
 """.lstrip().removesuffix("\n")
 

--- a/terraform/modules/lambdas/functions/utilities/messages.py
+++ b/terraform/modules/lambdas/functions/utilities/messages.py
@@ -88,12 +88,12 @@ You are a highly skilled assistant specializing in Infrastructure as Code (IaC),
    - ALWAYS provide a code snippet that directly addresses the error or warning.
    - Include only the relevant block of code that needs correction.
 
-3. **Full Corrected File**:
-   - ALWAYS provide the full content of the corrected file at the END of your response.
-   - Use the following strict format for corrected files:
-     - Start with the line: Corrected file `<relative_path_to_file>`
-     - ALWAYS add a blank new line immediately after this line.
-     - Then include the corrected file content inside a code block, using triple backticks (` ``` `) with the appropriate language identifier (e.g., `hcl` for Terraform files).
+3. **Full Corrected File(s)**:
+   - ALWAYS provide the full content of every corrected file at the END of your response.
+   - Use the following strict format for each corrected file:
+     - Start with the line: Corrected file `<relative_path_to_file>` — the path MUST always be enclosed in backticks.
+     - ALWAYS add a single blank line immediately after this line, with no other text in between.
+     - Then include the full corrected file content inside a code block, using triple backticks (` ``` `) with the `hcl` language identifier.
 
      The corrected file format MUST look like this:
      Corrected file `<relative_path_to_file>`
@@ -101,6 +101,9 @@ You are a highly skilled assistant specializing in Infrastructure as Code (IaC),
      ```hcl
      <file content>
      ```
+
+   - If more than one file needs correction, repeat this exact marker-plus-code-fence pattern once per file, back to back, at the end of your response — one complete block per file.
+   - Never wrap your entire response, or any "Corrected file" block, inside an outer code fence, and never let a stray triple-backtick fence appear inside a corrected file's content — either breaks how your response is parsed.
 
 4. **Scope of Correction**:
    - ONLY correct source files directly related to the error or warning messages.
@@ -116,8 +119,5 @@ You are a highly skilled assistant specializing in Infrastructure as Code (IaC),
 
 Your primary goal is to provide system engineers with reliable, actionable solutions for IaC, cloud automation, and DevOps tasks, ensuring their configurations are error-free and optimized for AWS environments.
 
-IMPORTANT: The part `<relative_path_to_file>` in line Corrected file `<relative_path_to_file>` MUST always:
-   - Be enclosed in backticks (` ` `) for proper formatting.
-   - Be followed by a blank new line.
-   - Ensure the corrected file content starts on a new line within a properly formatted code block.
+Before finishing your response, verify it contains exactly one "Corrected file" block, in the exact format above, for every file that needed a fix.
 """

--- a/terraform/modules/lambdas/functions/utilities/messages.py
+++ b/terraform/modules/lambdas/functions/utilities/messages.py
@@ -63,7 +63,11 @@ Response from AI
 
 ---
 
-<details><summary>Show AI suggestions and fixed files</summary>\n\n{ai_response}</details>
+<details>
+<summary>Show AI suggestions and fixed files</summary>
+
+{ai_response}
+</details>
 
 ---
 

--- a/terraform/modules/lambdas/functions/utilities/messages.py
+++ b/terraform/modules/lambdas/functions/utilities/messages.py
@@ -43,7 +43,7 @@ List of files corrected by AI bot
 
 ---
 
-"""
+""".lstrip().removesuffix("\n")
 
 UNAVAILABLE_APPROVAL_FILES_MESSAGE: str = """
 :information_source: AI Bot message

--- a/terraform/modules/lambdas/functions/utilities/messages.py
+++ b/terraform/modules/lambdas/functions/utilities/messages.py
@@ -79,7 +79,7 @@ Response from AI
 
 :arrow_double_up: Completion tokens: `{completion_tokens}`</details>
 
-"""
+""".lstrip().removesuffix("\n")
 
 SYSTEM_ROLE_MESSAGE: str = """
 You are a highly skilled assistant specializing in Infrastructure as Code (IaC), cloud automation, and DevOps practices using AWS as the cloud provider. You are proficient in tools such as Terraform, Terragrunt, and TFLint, and your role is to provide accurate, detailed, and practical guidance to system engineers. Follow these principles strictly:
@@ -125,3 +125,6 @@ Your primary goal is to provide system engineers with reliable, actionable solut
 
 Before finishing your response, verify it contains exactly one "Corrected file" block, in the exact format above, for every file that needed a fix.
 """.lstrip().removesuffix("\n")
+
+# print(AI_RESPONSE_MESSAGE)
+# print("<--")


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce? -->
- [ ] New feature (feat)
- [x] Bug fix (fix)
- [ ] Documentation (docs)
- [ ] Refactor (refactor)
- [ ] Chore (chore)

## Why we need this PR
`utilities/parsers.py::parse_hcl_blocks` regex-matches the "Corrected file" marker to turn the AI's response into `{path: content}` artifacts. The previous prompt wording was singular/ambiguous about multi-file fixes and didn't guard against nested code fences, both of which could cause artifact extraction to silently fail or mis-parse when the model corrected more than one file.

## What was done
- Extends the `SYSTEM_ROLE_MESSAGE` prompt in `terraform/modules/lambdas/functions/utilities/messages.py` to explicitly support **multiple** "Corrected file" blocks in a single AI response, instead of implying only one file is ever corrected.
- Tightens the formatting rules the model must follow for each block: the path must always be wrapped in backticks, exactly one blank line must follow the marker line, and the code fence must use the `hcl` language identifier.
- Adds an explicit prohibition against nesting the response (or any "Corrected file" block) inside an outer code fence, and against stray triple-backtick fences inside corrected file content, since either would break `parse_hcl_blocks` extraction.
- Replaces the old closing "IMPORTANT" reminder with a self-check instruction telling the model to verify it produced exactly one "Corrected file" block per file that needed a fix before finishing its response.

## How it was tested
- [x] Manually
- [x] Automatically
